### PR TITLE
feat(sessions): pin folders to the top of the session drawer

### DIFF
--- a/server/sessionUiState.ts
+++ b/server/sessionUiState.ts
@@ -24,6 +24,7 @@ export type SessionUnreadState = {
 export type SessionUiState = {
   version: 1;
   pinnedSessions: PinnedSession[];
+  pinnedFolders: string[];
   sessionMarkers: SessionMarker[];
   sessionUnreadStates: SessionUnreadState[];
   selectedMarkerColor: SessionMarkerColorId;
@@ -31,6 +32,7 @@ export type SessionUiState = {
 
 export type SessionUiStatePatch = Partial<{
   pinnedSessions: unknown;
+  pinnedFolders: unknown;
   sessionMarkers: unknown;
   sessionUnreadStates: unknown;
   selectedMarkerColor: unknown;
@@ -48,6 +50,7 @@ const legacyBucketToColor: Record<string, SessionMarkerColorId> = {
 export const defaultSessionUiState: SessionUiState = {
   version: 1,
   pinnedSessions: [],
+  pinnedFolders: [],
   sessionMarkers: [],
   sessionUnreadStates: [],
   selectedMarkerColor: "blue",
@@ -65,6 +68,12 @@ function normalizeMarkerColor(value: unknown): SessionMarkerColorId | undefined 
   return typeof value === "string" && markerColors.has(value as SessionMarkerColorId)
     ? value as SessionMarkerColorId
     : undefined;
+}
+
+function normalizePinnedFolder(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 function normalizePinnedSession(value: unknown): PinnedSession | undefined {
@@ -114,6 +123,10 @@ export function normalizeSessionUiState(value: unknown): SessionUiState {
     state.pinnedSessions = uniqueBy(value.pinnedSessions.map(normalizePinnedSession).filter(Boolean) as PinnedSession[], (item) => item.id);
   }
 
+  if (Array.isArray(value.pinnedFolders)) {
+    state.pinnedFolders = uniqueBy(value.pinnedFolders.map(normalizePinnedFolder).filter(Boolean) as string[], (item) => item);
+  }
+
   if (Array.isArray(value.sessionMarkers)) {
     state.sessionMarkers = uniqueBy(value.sessionMarkers.map(normalizeSessionMarker).filter(Boolean) as SessionMarker[], (item) => item.sessionId);
   }
@@ -132,6 +145,10 @@ export function applySessionUiStatePatch(current: SessionUiState, patch: unknown
 
   if ("pinnedSessions" in patch && Array.isArray(patch.pinnedSessions)) {
     next.pinnedSessions = uniqueBy(patch.pinnedSessions.map(normalizePinnedSession).filter(Boolean) as PinnedSession[], (item) => item.id);
+  }
+
+  if ("pinnedFolders" in patch && Array.isArray(patch.pinnedFolders)) {
+    next.pinnedFolders = uniqueBy(patch.pinnedFolders.map(normalizePinnedFolder).filter(Boolean) as string[], (item) => item);
   }
 
   if ("sessionMarkers" in patch && Array.isArray(patch.sessionMarkers)) {

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -86,6 +86,7 @@ export type SessionUnreadState = { sessionId: string; unreadAt: string; updatedA
 export type SessionUiState = {
   version: 1;
   pinnedSessions: PinnedSession[];
+  pinnedFolders: string[];
   sessionMarkers: SessionMarker[];
   sessionUnreadStates: SessionUnreadState[];
   selectedMarkerColor: SessionMarkerColorId;
@@ -102,6 +103,7 @@ export const sessionMarkerColors: SessionMarkerColor[] = [
 export const defaultSessionUiState: SessionUiState = {
   version: 1,
   pinnedSessions: [],
+  pinnedFolders: [],
   sessionMarkers: [],
   sessionUnreadStates: [],
   selectedMarkerColor: "blue",
@@ -117,6 +119,7 @@ const legacyMarkerBucketToColor: Record<string, SessionMarkerColorId> = {
 };
 
 const pinnedSessionsKey = "pi-web-pinned-sessions";
+const pinnedFoldersKey = "pi-web-pinned-folders";
 const sessionMarkersKey = "pi-web-session-markers";
 const selectedMarkerColorKey = "pi-web-selected-session-marker-color";
 
@@ -124,6 +127,19 @@ export function normalizeMarkerColor(value: unknown): SessionMarkerColorId | und
   return typeof value === "string" && markerColorIds.has(value as SessionMarkerColorId)
     ? value as SessionMarkerColorId
     : undefined;
+}
+
+export function normalizePinnedFolders(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of value) {
+    const cwd = typeof item === "string" ? item.trim() : "";
+    if (!cwd || seen.has(cwd)) continue;
+    seen.add(cwd);
+    result.push(cwd);
+  }
+  return result;
 }
 
 export function normalizePinnedSessions(value: unknown): PinnedSession[] {
@@ -175,6 +191,7 @@ export function normalizeSessionUiState(value: unknown): SessionUiState {
   return {
     version: 1,
     pinnedSessions: normalizePinnedSessions(raw.pinnedSessions),
+    pinnedFolders: normalizePinnedFolders(raw.pinnedFolders),
     sessionMarkers: normalizeSessionMarkers(raw.sessionMarkers),
     sessionUnreadStates: normalizeSessionUnreadStates(raw.sessionUnreadStates),
     selectedMarkerColor: normalizeMarkerColor(raw.selectedMarkerColor) || defaultSessionUiState.selectedMarkerColor,
@@ -184,6 +201,12 @@ export function normalizeSessionUiState(value: unknown): SessionUiState {
 export function readLegacyPinnedSessions(): PinnedSession[] {
   try {
     return normalizePinnedSessions(JSON.parse(localStorage.getItem(pinnedSessionsKey) || "[]"));
+  } catch { return []; }
+}
+
+export function readLegacyPinnedFolders(): string[] {
+  try {
+    return normalizePinnedFolders(JSON.parse(localStorage.getItem(pinnedFoldersKey) || "[]"));
   } catch { return []; }
 }
 
@@ -238,6 +261,7 @@ export type AppState = {
   connectionLostTimer: number | undefined;
   reconnectedClearTimer: number | undefined;
   pinnedSessions: PinnedSession[];
+  pinnedFolders: string[];
   sessionMarkers: SessionMarker[];
   sessionUnreadStates: SessionUnreadState[];
   selectedMarkerColor: SessionMarkerColorId;
@@ -323,6 +347,7 @@ export function createAppState(): AppState {
     connectionLostTimer: undefined,
     reconnectedClearTimer: undefined,
     pinnedSessions: readLegacyPinnedSessions(),
+    pinnedFolders: readLegacyPinnedFolders(),
     sessionMarkers: readLegacySessionMarkers(),
     sessionUnreadStates: [],
     selectedMarkerColor: readLegacySelectedMarkerColor() || defaultSessionUiState.selectedMarkerColor,

--- a/src/sessions/sessionDrawer.ts
+++ b/src/sessions/sessionDrawer.ts
@@ -361,6 +361,7 @@ export function createSessions(options: {
   function applySessionUiState(value: unknown) {
     const next = normalizeSessionUiState(value);
     state.pinnedSessions = next.pinnedSessions;
+    state.pinnedFolders = next.pinnedFolders;
     state.sessionMarkers = next.sessionMarkers;
     state.sessionUnreadStates = next.sessionUnreadStates;
     syncCachedUnreadFromState();
@@ -373,11 +374,12 @@ export function createSessions(options: {
     updateSessionButtonUnread();
     updateCurrentSessionPinButton();
     renderCurrentSessionBucketButton();
-    if (state.pinnedSessions.length > 0 && cachedSessions.length === 0) refreshSessions().catch(() => undefined);
+    if ((state.pinnedSessions.length > 0 || state.pinnedFolders.length > 0) && cachedSessions.length === 0) refreshSessions().catch(() => undefined);
   }
 
   function hasAnySessionUiState(value: SessionUiState) {
     return value.pinnedSessions.length > 0
+      || value.pinnedFolders.length > 0
       || value.sessionMarkers.length > 0
       || value.sessionUnreadStates.length > 0
       || value.selectedMarkerColor !== defaultSessionUiState.selectedMarkerColor;
@@ -408,6 +410,7 @@ export function createSessions(options: {
     const serverState = normalizeSessionUiState(data.sessionUiState);
     const localState = normalizeSessionUiState({
       pinnedSessions: state.pinnedSessions,
+      pinnedFolders: state.pinnedFolders,
       sessionMarkers: state.sessionMarkers,
       sessionUnreadStates: state.sessionUnreadStates,
       selectedMarkerColor: state.selectedMarkerColor,
@@ -901,6 +904,29 @@ export function createSessions(options: {
     else pinSession(item);
   }
 
+  function isPinnedFolder(cwd: string) {
+    return state.pinnedFolders.includes(cwd);
+  }
+
+  function pinFolder(cwd: string) {
+    if (!cwd || isPinnedFolder(cwd)) return;
+    state.pinnedFolders = [...state.pinnedFolders, cwd];
+    persistSessionUiState({ pinnedFolders: state.pinnedFolders });
+    renderSessionList(cachedSessions);
+  }
+
+  function unpinFolder(cwd: string) {
+    if (!isPinnedFolder(cwd)) return;
+    state.pinnedFolders = state.pinnedFolders.filter((value) => value !== cwd);
+    persistSessionUiState({ pinnedFolders: state.pinnedFolders });
+    renderSessionList(cachedSessions);
+  }
+
+  function toggleFolderPin(cwd: string) {
+    if (isPinnedFolder(cwd)) unpinFolder(cwd);
+    else pinFolder(cwd);
+  }
+
   function titleForSessionId(sessionId: string) {
     const live = cachedSessions.find((s) => s.id === sessionId);
     const pinned = state.pinnedSessions.find((s) => s.id === sessionId);
@@ -1245,9 +1271,24 @@ export function createSessions(options: {
       groups.set(cwd, [...(groups.get(cwd) || []), item]);
     }
 
-    for (const [cwd, items] of groups) {
+    // Partition cwds into pinned (in pin order) and rest (existing recency-based order),
+    // so pinned folders never reshuffle when the user switches sessions. Pinned folders
+    // with no sessions are still rendered as ghost rows so the user can unpin them.
+    const pinnedFolderSet = new Set(state.pinnedFolders);
+    const orderedCwds: string[] = [];
+    for (const cwd of state.pinnedFolders) {
+      if (!groups.has(cwd)) groups.set(cwd, []);
+      orderedCwds.push(cwd);
+    }
+    for (const cwd of groups.keys()) {
+      if (!pinnedFolderSet.has(cwd)) orderedCwds.push(cwd);
+    }
+
+    for (const cwd of orderedCwds) {
+      const items = groups.get(cwd) || [];
+      const folderPinned = pinnedFolderSet.has(cwd);
       const group = document.createElement("section");
-      group.className = "sessionFolderGroup";
+      group.className = `sessionFolderGroup${folderPinned ? " pinned" : ""}`;
 
       const header = document.createElement("div");
       header.className = "sessionFolderHeader";
@@ -1276,6 +1317,20 @@ export function createSessions(options: {
         renderSessionList(cachedSessions);
       });
 
+      const pinFolderButton = document.createElement("button");
+      pinFolderButton.type = "button";
+      pinFolderButton.className = `iconButton sessionFolderPinButton${folderPinned ? " pinned" : ""}`;
+      pinFolderButton.title = folderPinned
+        ? `Unpin folder ${folderName(cwd)} from the top of the drawer`
+        : `Pin folder ${folderName(cwd)} to the top of the drawer`;
+      pinFolderButton.setAttribute("aria-label", pinFolderButton.title);
+      pinFolderButton.setAttribute("aria-pressed", String(folderPinned));
+      setIcon(pinFolderButton, "pin");
+      pinFolderButton.addEventListener("click", (event) => {
+        event.stopPropagation();
+        toggleFolderPin(cwd);
+      });
+
       const newButton = document.createElement("button");
       newButton.type = "button";
       newButton.className = "iconButton sessionFolderNewButton";
@@ -1289,10 +1344,21 @@ export function createSessions(options: {
           addMessage("system", error instanceof Error ? error.message : String(error), "error");
         }
       });
-      header.append(toggle, newButton);
+      header.append(toggle, pinFolderButton, newButton);
       group.append(header);
 
       if (state.collapsedSessionFolders.has(cwd)) {
+        elements.sessionListEl.append(group);
+        continue;
+      }
+
+      // Pinned folders that no longer have any sessions still show a placeholder
+      // row so the folder header (and its unpin affordance) remains accessible.
+      if (items.length === 0) {
+        const placeholder = document.createElement("p");
+        placeholder.className = "sessionEmpty";
+        placeholder.textContent = "No sessions in this folder yet.";
+        group.append(placeholder);
         elements.sessionListEl.append(group);
         continue;
       }

--- a/src/styles/sessions.css
+++ b/src/styles/sessions.css
@@ -347,6 +347,44 @@
   width: 13px;
   height: 13px;
 }
+.sessionFolderPinButton {
+  flex: 0 0 auto;
+  width: 24px;
+  min-width: 24px;
+  height: 24px;
+  min-height: 24px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: color-mix(in srgb, var(--muted) 70%, transparent);
+  opacity: 0.45;
+  transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease;
+}
+.sessionFolderHeader:hover .sessionFolderPinButton {
+  opacity: 1;
+}
+.sessionFolderPinButton:hover {
+  border: none;
+  background: var(--panel-2);
+  color: var(--accent);
+  opacity: 1;
+}
+.sessionFolderPinButton svg {
+  width: 12px;
+  height: 12px;
+}
+.sessionFolderPinButton.pinned {
+  color: var(--accent);
+  opacity: 1;
+}
+.sessionFolderGroup.pinned > .sessionFolderHeader .sessionFolderName {
+  color: var(--accent);
+}
+.sessionFolderGroup.pinned + .sessionFolderGroup:not(.pinned) {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
+}
 .sessionFolderMoreButton {
   height: 28px;
   min-height: 28px;

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -210,6 +210,7 @@ describe("pi-web mock API", () => {
     const initial = await (await fetch(`${baseUrl}/api/session-ui-state`)).json();
     expect(initial.sessionUiState.pinnedSessions).toEqual([]);
     expect(initial.sessionUiState.sessionUnreadStates).toEqual([]);
+    expect(initial.sessionUiState.pinnedFolders).toEqual([]);
     expect(initial.sessionUiState.selectedMarkerColor).toBe("blue");
 
     const patchedRes = await fetch(`${baseUrl}/api/session-ui-state`, {
@@ -217,6 +218,7 @@ describe("pi-web mock API", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         pinnedSessions: [{ id: "mock-current", label: "Current mock session", cwd: "." }],
+        pinnedFolders: ["/work/repo-a", "/work/repo-b", "/work/repo-a", "", "  "],
         sessionMarkers: [{ sessionId: "mock-older", color: "green", updatedAt: "2026-01-01T00:00:00.000Z" }],
         sessionUnreadStates: [{ sessionId: "mock-older", unreadAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-01-01T00:00:00.000Z" }],
         selectedMarkerColor: "green",
@@ -226,6 +228,7 @@ describe("pi-web mock API", () => {
     const patched = await patchedRes.json();
     expect(patched.sessionUiState).toMatchObject({
       pinnedSessions: [{ id: "mock-current", label: "Current mock session", cwd: "." }],
+      pinnedFolders: ["/work/repo-a", "/work/repo-b"],
       sessionMarkers: [{ sessionId: "mock-older", color: "green" }],
       sessionUnreadStates: [{ sessionId: "mock-older", unreadAt: "2026-01-01T00:00:00.000Z" }],
       selectedMarkerColor: "green",
@@ -243,6 +246,14 @@ describe("pi-web mock API", () => {
     const current = await (await fetch(`${baseUrl}/api/session-ui-state`)).json();
     expect(current.sessionUiState.selectedMarkerColor).toBe("green");
     expect(current.sessionUiState.sessionUnreadStates).toEqual([]);
+    expect(current.sessionUiState.pinnedFolders).toEqual(["/work/repo-a", "/work/repo-b"]);
+
+    // Reset for downstream tests.
+    await fetch(`${baseUrl}/api/session-ui-state`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ pinnedFolders: [] }),
+    });
   });
 
   it("applies saved defaults to new sessions", async () => {

--- a/tests/e2e/session-bar.spec.ts
+++ b/tests/e2e/session-bar.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 async function seedServerSessionUiState(page: import("@playwright/test").Page, state: {
   pinnedSessions?: Array<{ id: string; label: string; cwd?: string }>;
+  pinnedFolders?: string[];
   sessionMarkers?: Array<{ sessionId: string; color: string; updatedAt: string }>;
   sessionUnreadStates?: Array<{ sessionId: string; unreadAt: string; updatedAt: string }>;
 }) {
@@ -295,6 +296,81 @@ test.describe("session quick bar", () => {
     await expect(page.locator(".sessionItem")).toHaveCount(1);
     await expect(page.locator(".sessionItem")).toContainText("Older mock session");
     await expect(page.locator(".sessionFolderGroup .sessionEmpty")).toHaveCount(2);
+  });
+
+  test("session drawer pins folders to the top regardless of session activity order", async ({ page }) => {
+    await page.route("**/api/sessions**", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [
+          {
+            id: "mock-current",
+            name: "Current mock session",
+            firstMessage: "Latest activity is in folder-a",
+            modified: "2026-05-07T10:00:00.000Z",
+            messageCount: 2,
+            cwd: "/workspace/folder-a",
+            isCurrent: true,
+          },
+          {
+            id: "mock-older",
+            name: "Older mock session",
+            firstMessage: "Older activity in folder-b",
+            modified: "2026-05-06T09:00:00.000Z",
+            messageCount: 4,
+            cwd: "/workspace/folder-b",
+            isCurrent: false,
+          },
+          {
+            id: "mock-third",
+            name: "Third session",
+            firstMessage: "Even older folder-c",
+            modified: "2026-05-05T09:00:00.000Z",
+            messageCount: 1,
+            cwd: "/workspace/folder-c",
+            isCurrent: false,
+          },
+        ] }),
+      });
+    });
+
+    await page.goto("/");
+    await page.locator("#sessionButton").click();
+
+    // Default order is by recency: folder-a, folder-b, folder-c.
+    await expect(page.locator(".sessionFolderName")).toContainText(["folder-a", "folder-b", "folder-c"]);
+
+    // Pin folder-c. It should jump to the top and stay there.
+    const folderCGroup = page.locator(".sessionFolderGroup", { has: page.locator(".sessionFolderName", { hasText: "folder-c" }) });
+    await folderCGroup.locator(".sessionFolderPinButton").click();
+    await expect(folderCGroup).toHaveClass(/\bpinned\b/);
+    await expect(page.locator(".sessionFolderName")).toContainText(["folder-c", "folder-a", "folder-b"]);
+
+    // Pin folder-b too — pinned region appends in pin order.
+    const folderBGroup = page.locator(".sessionFolderGroup", { has: page.locator(".sessionFolderName", { hasText: "folder-b" }) });
+    await folderBGroup.locator(".sessionFolderPinButton").click();
+    await expect(page.locator(".sessionFolderName")).toContainText(["folder-c", "folder-b", "folder-a"]);
+
+    // Persisted server-side.
+    const stored = await (await page.request.get("/api/session-ui-state")).json();
+    expect(stored.sessionUiState.pinnedFolders).toEqual(["/workspace/folder-c", "/workspace/folder-b"]);
+
+    // Pin survives a marker-color filter that hides every session in the pinned folder.
+    await seedServerSessionUiState(page, {
+      sessionMarkers: [{ sessionId: "mock-current", color: "green", updatedAt: "2026-01-01T00:00:00.000Z" }],
+    });
+    await page.locator(".sessionColorFilterButton").click();
+    await page.locator(".sessionColorFilterMenuItem.marker-green").click();
+    await expect(page.locator(".sessionFolderName")).toContainText(["folder-c", "folder-b", "folder-a"]);
+
+    // Unpin folder-c, ordering reverts to recency for that folder.
+    await page.locator(".sessionColorFilterButton").click();
+    await page.locator(".sessionColorFilterMenuItem.all").click();
+    await page.locator(".sessionColorFilterButton").click({ force: true });
+    // Close any lingering menu by pressing Escape.
+    await page.keyboard.press("Escape");
+    await folderCGroup.locator(".sessionFolderPinButton").click();
+    await expect(page.locator(".sessionFolderName")).toContainText(["folder-b", "folder-a", "folder-c"]);
   });
 
   test("session drawer uses selected marker colors and one-line marker actions", async ({ page }) => {


### PR DESCRIPTION
## What

Adds the ability to **pin folders (cwd groups) to the top of the session drawer**. Each folder header gets a small pin/unpin button; pinned folders sort to the top in pin order and stay there across session switches, filter changes, and reloads — so the drawer behaves like a stable spatial map instead of a recency-ordered log.

## Why

With many concurrent sessions across several repos, the recency-ordered drawer constantly reshuffles, making it hard to find the folder you care about. Pinning lets you keep your active repos anchored at the top.

## Behaviour

- Each folder header gets a pin/unpin icon button (lucide `pin`).
- State persists per-device via the existing `pi-web-session-ui-state.json` round-trip (new `pinnedFolders: string[]` field) — same mechanism as pinned sessions and markers, so it survives reloads and syncs through the server.
- Pinned folders render above unpinned folders in pin order; unpinned folders keep the existing recency-based order.
- A pinned folder whose sessions are hidden by an active marker-color/search filter still keeps its header (and unpin affordance) visible.
- A pinned folder with no sessions left renders a small placeholder row so it can still be unpinned.
- Touch devices keep the pin button visible (it doesn't rely on hover).

## Implementation

- `server/sessionUiState.ts` — `pinnedFolders` added to the state shape, normalizer, and PATCH handler.
- `src/app/types.ts` — `pinnedFolders` in `SessionUiState` + `AppState`, with normalize/legacy-read helpers.
- `src/sessions/sessionDrawer.ts` — pin/unpin/toggle helpers, partition-by-pinned render ordering, pin button + ghost-row placeholder.
- `src/styles/sessions.css` — pin button + pinned-group separator styles.

## Tests

- `tests/api.test.ts` — round-trips `pinnedFolders` through the `/api/session-ui-state` PATCH (dedupe + trim + reset).
- `tests/e2e/session-bar.spec.ts` — e2e coverage for pin/unpin + ordering.

Verification output (typecheck / build / unit tests green) posted as a PR comment.
