### PR TITLE
Extract typed session projections

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -29,6 +29,19 @@ import { assertDirectory, createDirectory, listDirectories } from "./server/shar
 import { gitCommitDetails, gitCwdFromRepoParam, gitDiff, gitImageBase64, gitLog, gitStatus, gitSync, isGitRepo, listGitRepos } from "./server/shared/git.js";
 import type { PiWebFooter, PiWebGitTab, PiWebHeaderAction, PiWebUi } from "./src/extensions.js";
 import type { PiWebSession } from "./server/types.js";
+import {
+  hasUserMessages,
+  isAssistantAbortedMessage,
+  isAssistantFailureMessage,
+  isIncompleteToolResultMessage,
+  messageEntryRefs as projectMessageEntryRefs,
+  projectConversationTree,
+  projectSessionState,
+  projectSessionStats,
+  projectSessionTitle,
+  simplifyMessage as projectSimplifiedMessage,
+  simplifyModel,
+} from "./server/session/projection.js";
 
 const appDir = resolve(fileURLToPath(new URL(".", import.meta.url)));
 const distDir = join(appDir, "dist");
@@ -164,35 +177,6 @@ function serveStatic(req: IncomingMessage, res: ServerResponse) {
   pipeReadStream(res, file);
 }
 
-function textFromContent(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content.map((part) => {
-    if (!part || typeof part !== "object") return "";
-    const p = part as Record<string, unknown>;
-    if (p.type === "text" && typeof p.text === "string") return p.text;
-    if (p.type === "image") return "[image]";
-    // toolCall parts are rendered as tool cards in the UI — omit from text
-    return "";
-  }).filter(Boolean).join("\n");
-}
-
-function simplifyModel(model: any) {
-  if (!model) return undefined;
-  return {
-    provider: model.provider,
-    id: model.id,
-    name: model.name || model.id,
-    reasoning: Boolean(model.reasoning),
-    contextWindow: model.contextWindow,
-    maxTokens: model.maxTokens,
-  };
-}
-
-function hasUserMessages(value: PiWebSession) {
-  return value.messages.some((message: any) => message?.role === "user");
-}
-
 async function ensurePiWebStorage(cwd = piCwd) {
   const webDir = join(cwd, ".pi", "web");
   await mkdir(webDir, { recursive: true });
@@ -311,327 +295,23 @@ function contentWithToolStartedAts(content: unknown, sessionFile?: string) {
   });
 }
 
-function appendMessageEntryRef(refs: Array<{ entryId?: string }>, entry: any) {
-  if (!entry || typeof entry !== "object") return;
-  if (entry.type === "message" || entry.type === "custom_message" || entry.type === "branch_summary" && entry.summary) {
-    const entryId = typeof entry.id === "string" && entry.id.trim() ? entry.id : undefined;
-    refs.push({ entryId });
-  }
-}
-
-function messageEntryRefs(targetSession: PiWebSession): Array<{ entryId?: string }> {
+function messageEntryRefs(targetSession: PiWebSession) {
   const getBranch = targetSession.sessionManager?.getBranch;
   if (typeof getBranch !== "function") return [];
-
-  let branch: any[];
   try {
-    branch = getBranch.call(targetSession.sessionManager);
+    const branch = getBranch.call(targetSession.sessionManager);
+    return Array.isArray(branch) ? projectMessageEntryRefs(branch) : [];
   } catch {
     return [];
   }
-  if (!Array.isArray(branch)) return [];
-
-  const refs: Array<{ entryId?: string }> = [];
-  let compaction: any | undefined;
-  for (const entry of branch) {
-    if (entry?.type === "compaction") compaction = entry;
-  }
-
-  if (!compaction) {
-    for (const entry of branch) appendMessageEntryRef(refs, entry);
-    return refs;
-  }
-
-  const compactionId = typeof compaction.id === "string" && compaction.id.trim() ? compaction.id : undefined;
-  refs.push({ entryId: compactionId });
-  const compactionIndex = branch.findIndex((entry) => entry?.type === "compaction" && entry?.id === compaction.id);
-  let foundFirstKept = false;
-  for (let index = 0; index < compactionIndex; index += 1) {
-    const entry = branch[index];
-    if (entry?.id === compaction.firstKeptEntryId) foundFirstKept = true;
-    if (foundFirstKept) appendMessageEntryRef(refs, entry);
-  }
-  for (let index = compactionIndex + 1; index < branch.length; index += 1) appendMessageEntryRef(refs, branch[index]);
-  return refs;
 }
 
+// Runtime tool timestamps are host state; the projection receives the decorated message.
 function simplifyMessage(message: unknown, toolCallArgs?: Map<string, Record<string, unknown>>, sessionFile?: string, entryId?: string) {
-  if (!message || typeof message !== "object") return message;
-  const m = message as Record<string, unknown>;
-  const content = contentWithToolStartedAts(m.content, sessionFile);
-  const entry = entryId ? { entryId } : {};
-  if (m.role === "bashExecution") {
-    return {
-      ...entry,
-      role: "bashExecution",
-      command: m.command,
-      output: m.output,
-      exitCode: m.exitCode,
-      cancelled: Boolean(m.cancelled),
-      truncated: Boolean(m.truncated),
-      fullOutputPath: m.fullOutputPath,
-      excludeFromContext: Boolean(m.excludeFromContext),
-      timestamp: m.timestamp,
-      raw: m,
-    };
-  }
-  if (m.role === "toolResult") {
-    const args = toolCallArgs?.get(m.toolCallId as string);
-    return {
-      ...entry,
-      role: "toolResult",
-      toolCallId: m.toolCallId,
-      toolName: m.toolName,
-      toolArgs: args,
-      isError: Boolean(m.isError),
-      text: textFromContent(m.content),
-      timestamp: m.timestamp,
-      raw: m,
-    };
-  }
-  const text = textFromContent(content);
-  const errorText = m.role === "assistant" && m.errorMessage ? assistantErrorPreview(m) : "";
-  const stopReasonText = m.role === "assistant" && !errorText ? assistantStopReasonPreview(m) : "";
-  const displayText = errorText || (text && stopReasonText ? `${text}\n\n${stopReasonText}` : stopReasonText || text);
-  const toolCalls = m.role === "assistant" && Array.isArray(content)
-    ? content.filter((part: any) => part?.type === "toolCall").map((part: any) => ({
-      id: part.id,
-      toolName: part.toolName || part.name || "tool",
-      args: part.arguments || part.args || {},
-      startedAt: part.startedAt,
-    }))
-    : undefined;
-  return {
-    ...entry,
-    role: m.role,
-    text: displayText,
-    toolCalls,
-    isError: Boolean(m.errorMessage || m.stopReason === "error" || stopReasonText),
-    timestamp: m.timestamp,
-    raw: content === m.content ? m : { ...m, content },
-  };
-}
-
-function truncatePreview(value: string, max = 220) {
-  const text = value.replace(/\s+/g, " ").trim();
-  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
-}
-
-function entryMessage(entry: any) {
-  if (entry?.type === "message") return entry.message;
-  if (entry?.type === "custom_message") return { role: "custom", content: entry.content, timestamp: entry.timestamp };
-  return undefined;
-}
-
-function messageToolCalls(message: any) {
-  return Array.isArray(message?.content)
-    ? message.content.filter((part: any) => part?.type === "toolCall")
-    : [];
-}
-
-function toolCallName(part: any) {
-  return String(part?.toolName || part?.name || "tool");
-}
-
-function toolCallArgs(part: any) {
-  const args = part?.arguments || part?.args;
-  return args && typeof args === "object" ? args as Record<string, unknown> : {};
-}
-
-function shortArg(value: unknown, max = 90) {
-  const text = typeof value === "string" ? value : JSON.stringify(value ?? "");
-  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
-}
-
-function toolCallPreview(part: any) {
-  const name = toolCallName(part);
-  const args = toolCallArgs(part);
-  if (name === "bash" && typeof args.command === "string") return `Tool call: bash ${shortArg(args.command, 120)}`;
-  if (typeof args.path === "string") return `Tool call: ${name} ${shortArg(args.path, 120)}`;
-  if (typeof args.query === "string") return `Tool call: ${name} ${shortArg(args.query, 120)}`;
-  if (typeof args.pattern === "string") return `Tool call: ${name} ${shortArg(args.pattern, 120)}`;
-  const first = Object.entries(args).find(([, value]) => typeof value === "string" || typeof value === "number" || typeof value === "boolean");
-  return first ? `Tool call: ${name} ${first[0]}=${shortArg(first[1], 90)}` : `Tool call: ${name}`;
-}
-
-function toolCallsPreview(message: any) {
-  const calls = messageToolCalls(message);
-  if (calls.length === 0) return "";
-  const [first] = calls;
-  const suffix = calls.length > 1 ? ` + ${calls.length - 1} more` : "";
-  return `${toolCallPreview(first)}${suffix}`;
-}
-
-function messageTextPreview(message: any) {
-  return textFromContent(message?.content || "");
-}
-
-const assistantHttpErrorLabels: Record<string, string> = {
-  "429": "Throttling error",
-  "500": "Server error",
-  "502": "Bad gateway",
-  "503": "Service unavailable",
-  "504": "Gateway timeout",
-  "529": "Overloaded",
-};
-
-function isAssistantHttpErrorStatus(code: string) {
-  return code in assistantHttpErrorLabels || /^[45]\d\d$/.test(code);
-}
-
-function assistantStatusLabel(label: string | undefined, code: string) {
-  const clean = (label || "").replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
-  if (!clean || /^(?:http|status|error|request failed|model request failed)$/i.test(clean)) return assistantHttpErrorLabels[code] || `HTTP ${code}`;
-  return clean;
-}
-
-function assistantStatusErrorPreview(text: string) {
-  const labelled = text.match(/^([A-Za-z][A-Za-z0-9 _/-]*?):\s*(\d{3})(?=$|[\s:,-])/);
-  if (labelled && isAssistantHttpErrorStatus(labelled[2])) return `${assistantStatusLabel(labelled[1], labelled[2])} (${labelled[2]})`;
-  const leading = text.match(/^(?:HTTP\s*)?(\d{3})(?=$|[\s:,-])/i);
-  if (leading && isAssistantHttpErrorStatus(leading[1])) return `${assistantStatusLabel(undefined, leading[1])} (${leading[1]})`;
-  const generic = text.match(/^(Error|Request failed|Model request failed)\s*:?\s*(\d{3})(?=$|[\s:,-])/i);
-  if (generic && isAssistantHttpErrorStatus(generic[2])) return `${assistantStatusLabel(generic[1], generic[2])} (${generic[2]})`;
-  return "";
-}
-
-function assistantParsedErrorDetail(parsed: any) {
-  if (typeof parsed === "string") return parsed.trim();
-  if (!parsed || typeof parsed !== "object") return "";
-  if (parsed.error && typeof parsed.error === "object") return parsed.error.message || parsed.error.type || "";
-  return parsed.message || parsed.detail || parsed.error_description || "";
-}
-
-function assistantJsonErrorPreview(text: string) {
-  const trimmed = text.trim();
-  if (!((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]")))) return "";
-  try {
-    const detail = assistantParsedErrorDetail(JSON.parse(trimmed));
-    return detail ? `Error: ${detail}` : "";
-  } catch {
-    return "";
-  }
-}
-
-function assistantErrorPreview(message: any) {
-  const raw = String(message?.errorMessage || "").trim();
-  if (!raw) return "";
-  const jsonText = raw.replace(/^Codex error:\s*/i, "").trim();
-  return assistantJsonErrorPreview(jsonText)
-    || assistantStatusErrorPreview(jsonText)
-    || assistantStatusErrorPreview(raw)
-    || (raw.length > 180 ? `${raw.slice(0, 179)}…` : raw);
-}
-
-function assistantStopReasonPreview(message: any) {
-  const reason = String(message?.stopReason || "").trim();
-  if (!reason || reason === "stop" || reason === "toolUse") return "";
-  if (reason === "length") return "Response stopped because the model hit its output length limit.";
-  if (reason === "aborted") return "Response was aborted.";
-  return `Response stopped unexpectedly: ${reason}`;
-}
-
-function entryRole(entry: any) {
-  const message = entryMessage(entry);
-  if (message?.role === "assistant" && !messageTextPreview(message).trim()) {
-    if (messageToolCalls(message).length > 0) return "toolCall";
-    if (message.errorMessage || assistantStopReasonPreview(message)) return "error";
-  }
-  if (message?.role) return String(message.role);
-  switch (entry?.type) {
-    case "branch_summary": return "branchSummary";
-    case "compaction": return "compaction";
-    case "model_change": return "model";
-    case "thinking_level_change": return "thinking";
-    case "session_info": return "session";
-    case "label": return "label";
-    case "custom": return "custom";
-    default: return String(entry?.type || "entry");
-  }
-}
-
-function entryPreview(entry: any) {
-  const message = entryMessage(entry);
-  if (message) {
-    if (message.role === "toolResult") {
-      const text = textFromContent(message.content);
-      return `Tool result: ${message.toolName || "tool"}${text ? ` — ${text}` : ""}`;
-    }
-    const text = messageTextPreview(message);
-    if (text.trim()) return text;
-    const calls = toolCallsPreview(message);
-    if (calls) return calls;
-    const error = assistantErrorPreview(message);
-    if (error) return error;
-    const stopReason = assistantStopReasonPreview(message);
-    if (stopReason) return stopReason;
-    return message.role === "assistant" ? "Empty assistant message" : `${message.role || "Message"} message`;
-  }
-  switch (entry?.type) {
-    case "branch_summary": return entry.summary || "Branch summary";
-    case "compaction": return entry.summary || "Compaction summary";
-    case "model_change": return `Model changed to ${entry.provider || "provider"}/${entry.modelId || "model"}`;
-    case "thinking_level_change": return `Thinking level changed to ${entry.thinkingLevel || "unknown"}`;
-    case "session_info": return entry.name ? `Session named ${entry.name}` : "Session name cleared";
-    case "label": return entry.label ? `Label ${entry.targetId || "entry"} as ${entry.label}` : `Clear label on ${entry.targetId || "entry"}`;
-    case "custom": return `Custom entry${entry.customType ? `: ${entry.customType}` : ""}`;
-    default: return String(entry?.type || "Entry");
-  }
-}
-
-function countTreeNodes(nodes: any[]): number {
-  let count = 0;
-  const stack = [...nodes];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    count += 1;
-    const children = Array.isArray(node?.children) ? node.children : [];
-    for (const child of children) stack.push(child);
-  }
-  return count;
-}
-
-function countBranchPoints(nodes: any[]): number {
-  let count = 0;
-  const stack = [...nodes];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    const children = Array.isArray(node?.children) ? node.children : [];
-    if (children.length > 1) count += 1;
-    for (const child of children) stack.push(child);
-  }
-  return count;
-}
-
-function simpleTreeNode(node: any, activePathIds: Set<string>, leafId: string | null, childCount: number): any {
-  const entry = node?.entry || node;
-  const id = String(entry?.id || "");
-  return {
-    id,
-    parentId: typeof entry?.parentId === "string" ? entry.parentId : null,
-    type: String(entry?.type || "entry"),
-    role: entryRole(entry),
-    preview: truncatePreview(entryPreview(entry)),
-    timestamp: String(entry?.timestamp || ""),
-    label: typeof node?.label === "string" ? node.label : undefined,
-    labelTimestamp: typeof node?.labelTimestamp === "string" ? node.labelTimestamp : undefined,
-    childCount,
-    isOnActivePath: activePathIds.has(id),
-    isCurrentLeaf: Boolean(leafId && id === leafId),
-    children: [],
-  };
-}
-
-function simplifyTreeNodesFlat(roots: any[], activePathIds: Set<string>, leafId: string | null): any[] {
-  const nodes: any[] = [];
-  const stack = [...roots].reverse();
-  while (stack.length > 0) {
-    const node = stack.pop();
-    const children = Array.isArray(node?.children) ? node.children : [];
-    nodes.push(simpleTreeNode(node, activePathIds, leafId, children.length));
-    for (let index = children.length - 1; index >= 0; index -= 1) stack.push(children[index]);
-  }
-  return nodes;
+  if (!message || typeof message !== "object") return projectSimplifiedMessage(message, toolCallArgs, entryId);
+  const value = message as Record<string, unknown>;
+  const content = contentWithToolStartedAts(value.content, sessionFile);
+  return projectSimplifiedMessage(content === value.content ? message : { ...value, content }, toolCallArgs, entryId);
 }
 
 function conversationTreeForSession(targetSession: PiWebSession) {
@@ -639,21 +319,15 @@ function conversationTreeForSession(targetSession: PiWebSession) {
   if (typeof manager.getTree !== "function") throw new Error("Session tree is not available");
   const leafId = typeof manager.getLeafId === "function" ? manager.getLeafId() : null;
   const activePath = typeof manager.getBranch === "function" ? manager.getBranch() : [];
-  const activePathIds = new Set(activePath.map((entry: any) => String(entry?.id || "")).filter(Boolean));
-  const roots = manager.getTree();
-  const nodes = simplifyTreeNodesFlat(roots, activePathIds, leafId);
-  return {
-    ok: true,
+  return projectConversationTree({
     sessionId: targetSession.sessionId,
     leafId,
-    activePathIds: Array.from(activePathIds),
-    entryCount: nodes.length,
-    branchPointCount: nodes.filter((node: any) => node.childCount > 1).length,
-    nodes,
-  };
+    activePath,
+    roots: manager.getTree(),
+  });
 }
 
-function sessionCwd(targetSession: PiWebSession | any = session) {
+function sessionCwd(targetSession: PiWebSession | any) {
   return String(targetSession?.sessionManager?.getCwd?.() || targetSession?.cwd || piCwd);
 }
 
@@ -701,34 +375,6 @@ function clearRuntimeStartedAt(targetSession: any, sessionFile = sessionPathKey(
     delete targetSession.runtimeStartedAt;
     delete targetSession.runtimeLastActivityAt;
   }
-}
-
-function messageRole(message: any) {
-  return String(message?.role || message?.raw?.role || "");
-}
-
-function messageStopReason(message: any) {
-  return String(message?.stopReason || message?.raw?.stopReason || "");
-}
-
-function messageErrorText(message: any) {
-  return typeof message?.errorMessage === "string"
-    ? message.errorMessage
-    : typeof message?.raw?.errorMessage === "string"
-      ? message.raw.errorMessage
-      : "";
-}
-
-function isAssistantFailureMessage(message: any) {
-  return messageRole(message) === "assistant" && (messageStopReason(message) === "error" || Boolean(messageErrorText(message).trim()));
-}
-
-function isAssistantAbortedMessage(message: any) {
-  return messageRole(message) === "assistant" && messageStopReason(message) === "aborted";
-}
-
-function isIncompleteToolResultMessage(message: any) {
-  return messageRole(message) === "toolResult";
 }
 
 type RetrySessionTarget =
@@ -947,10 +593,6 @@ async function listSessionInfos(extraCwds: string[] = []) {
   return groups.flat().sort((a, b) => Date.parse(b.modified) - Date.parse(a.modified));
 }
 
-function finiteNumber(value: unknown) {
-  return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
-
 function sessionDisplayName(targetSession: PiWebSession) {
   return targetSession.getSessionName?.()?.trim()
     || targetSession.sessionName?.trim()
@@ -959,70 +601,22 @@ function sessionDisplayName(targetSession: PiWebSession) {
 }
 
 function liveSessionTitle(targetSession: PiWebSession) {
-  const name = sessionDisplayName(targetSession);
-  if (name) return name;
-
-  for (const message of targetSession.messages as any[]) {
-    const text = textFromContent(message?.content).trim();
-    if (message?.role === "user" && text) return truncatePreview(text, 80);
-  }
-  return "New session";
+  return projectSessionTitle(sessionDisplayName(targetSession), targetSession.messages);
 }
 
 function sessionStats(targetSession: PiWebSession) {
-  let input = 0;
-  let output = 0;
-  let cacheRead = 0;
-  let cacheWrite = 0;
-  let cost = 0;
-  let userMessages = 0;
-  let assistantMessages = 0;
-  let toolResults = 0;
-
   const branch = targetSession.sessionManager.getBranch?.();
   const entries = Array.isArray(branch) && branch.length > 0
     ? branch.map((entry: any) => entry?.message ?? entry)
     : targetSession.messages;
-
-  for (const message of entries as any[]) {
-    if (!message || typeof message !== "object") continue;
-    if (message.role === "user") userMessages++;
-    if (message.role === "toolResult") toolResults++;
-    if (message.role !== "assistant") continue;
-    assistantMessages++;
-    const usage = message.usage || {};
-    input += finiteNumber(usage.input);
-    output += finiteNumber(usage.output);
-    cacheRead += finiteNumber(usage.cacheRead);
-    cacheWrite += finiteNumber(usage.cacheWrite);
-    const usageCost = usage.cost || {};
-    const totalCost = finiteNumber(usageCost.total);
-    cost += totalCost || finiteNumber(usageCost.input) + finiteNumber(usageCost.output) + finiteNumber(usageCost.cacheRead) + finiteNumber(usageCost.cacheWrite);
-  }
-
-  const contextUsage = targetSession.getContextUsage?.() || undefined;
-  return {
-    userMessages,
-    assistantMessages,
-    toolResults,
-    totalMessages: entries.length,
-    tokens: {
-      input,
-      output,
-      cacheRead,
-      cacheWrite,
-      total: input + output + cacheRead + cacheWrite,
-    },
-    cost,
-    contextUsage,
-  };
+  return projectSessionStats(entries, targetSession.getContextUsage?.() || undefined);
 }
 
-function currentState(targetSession: PiWebSession = session) {
+function currentState(targetSession: PiWebSession) {
   const isRetrying = sessionIsRetrying(targetSession);
   const isRunning = Boolean(targetSession.isStreaming || isRetrying || targetSession.isCompacting);
   const runtime = runtimeForPath(targetSession.sessionFile);
-  return {
+  return projectSessionState({
     cwd: sessionCwd(targetSession),
     sessionFile: targetSession.sessionFile,
     sessionId: targetSession.sessionId,
@@ -1038,16 +632,16 @@ function currentState(targetSession: PiWebSession = session) {
       ? (targetSession as any).runtimeLastActivityAt
       : runtimeLastActivityAtForPath(targetSession.sessionFile, isRunning),
     runtime,
-    model: simplifyModel(targetSession.model),
+    model: targetSession.model,
     thinkingLevel: targetSession.thinkingLevel,
     stats: sessionStats(targetSession),
     webFooters: webFooterEntries(targetSession),
     webHeaderActions: webHeaderActionEntries(targetSession),
     webGitTabs: webGitTabEntries(targetSession),
-  };
+  });
 }
 
-function currentStateWithThinkingLevels(targetSession: PiWebSession = session) {
+function currentStateWithThinkingLevels(targetSession: PiWebSession) {
   return {
     ...currentState(targetSession),
     thinkingLevels: targetSession.getAvailableThinkingLevels(),
@@ -1834,7 +1428,7 @@ const mockHarness = createMockHarness({
   piCwd,
   broadcast,
   isCurrentSession: (value: PiWebSession) => value === session,
-  currentState,
+  currentState: () => currentState(session),
 });
 const { mockSessions, createMockSession, resetMockSessions, getMockLifecycle } = mockHarness;
 
@@ -2225,7 +1819,7 @@ async function transferCurrentTabUiState(oldSessionId: string, newSessionId: str
 async function switchEmptySessionCwd(targetSession: PiWebSession, cwd: string) {
   if (targetSession.isStreaming) throw new Error("Wait for the current response to finish before changing the working directory.");
   if (targetSession.isCompacting) throw new Error("Wait for compaction to finish before changing the working directory.");
-  if (hasUserMessages(targetSession)) throw new Error("Working directory can only be changed before the first message.");
+  if (hasUserMessages(targetSession.messages)) throw new Error("Working directory can only be changed before the first message.");
   const newSession = await createNewLiveSession(cwd, targetSession.sessionFile);
   return currentStateWithThinkingLevels(newSession);
 }
@@ -2260,7 +1854,7 @@ const server = createServer(async (req, res) => {
         await sessionUiStateStore.write(defaultSessionUiState);
         session = registerLiveSession(createMockSession());
         broadcast({ type: "session_ui_state_changed", sessionUiState: defaultSessionUiState });
-        broadcast({ type: "state_changed", ...currentState() });
+        broadcast({ type: "state_changed", ...currentState(session) });
         return sendJson(res, 200, { ok: true });
       }
 
@@ -2822,7 +2416,7 @@ const server = createServer(async (req, res) => {
           return sendJson(res, 404, { ok: false, error: "Session not found" });
         }
         noteViewerLeaseFromRequest(req, targetSession, body.clientId);
-        const state = currentStateWithThinkingLevels(targetSession);
+        const state = currentStateWithThinkingLevels(targetSession || session);
         return sendJson(res, 200, { ok: true, ...state });
       }
 
@@ -2885,7 +2479,7 @@ wss.on("connection", async (ws, req) => {
     acquireViewerLease(clientId, targetSession || session);
     bindViewerSocket(clientId, realtimeWs);
   }
-  const helloState = targetSession ? currentState(targetSession) : currentState();
+  const helloState = currentState(targetSession || session);
   realtimeWs.send(JSON.stringify({
     type: "hello",
     seq: latestSeq,

--- a/server/session/dto.ts
+++ b/server/session/dto.ts
@@ -1,0 +1,104 @@
+export interface SimplifiedModelDTO {
+  provider: unknown;
+  id: unknown;
+  name: unknown;
+  reasoning: boolean;
+  contextWindow: unknown;
+  maxTokens: unknown;
+}
+
+export interface MessageEntryRefDTO {
+  entryId?: string;
+}
+
+export interface SimplifiedToolCallDTO {
+  id: unknown;
+  toolName: unknown;
+  args: unknown;
+  startedAt: unknown;
+}
+
+export interface SimplifiedMessageDTO {
+  entryId?: string;
+  role: unknown;
+  text?: string;
+  toolCalls?: SimplifiedToolCallDTO[];
+  isError?: boolean;
+  timestamp?: unknown;
+  raw: Record<string, unknown>;
+  command?: unknown;
+  output?: unknown;
+  exitCode?: unknown;
+  cancelled?: boolean;
+  truncated?: boolean;
+  fullOutputPath?: unknown;
+  excludeFromContext?: boolean;
+  toolCallId?: unknown;
+  toolName?: unknown;
+  toolArgs?: Record<string, unknown>;
+}
+
+export interface ConversationTreeNodeDTO {
+  id: string;
+  parentId: string | null;
+  type: string;
+  role: string;
+  preview: string;
+  timestamp: string;
+  label?: string;
+  labelTimestamp?: string;
+  childCount: number;
+  isOnActivePath: boolean;
+  isCurrentLeaf: boolean;
+  children: never[];
+}
+
+export interface ConversationTreeDTO {
+  ok: true;
+  sessionId: string;
+  leafId: string | null;
+  activePathIds: string[];
+  entryCount: number;
+  branchPointCount: number;
+  nodes: ConversationTreeNodeDTO[];
+}
+
+export interface SessionStatsDTO {
+  userMessages: number;
+  assistantMessages: number;
+  toolResults: number;
+  totalMessages: number;
+  tokens: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
+  cost: number;
+  contextUsage: unknown;
+}
+
+export interface SessionStateProjectionInput {
+  cwd: string;
+  sessionFile: string;
+  sessionId: string;
+  sessionName: string | undefined;
+  sessionTitle: string;
+  isStreaming: unknown;
+  isRetrying: boolean;
+  isCompacting: boolean;
+  runtimeStartedAt: string | undefined;
+  runtimeLastActivityAt: string | undefined;
+  runtime: unknown;
+  model: unknown;
+  thinkingLevel: unknown;
+  stats: SessionStatsDTO;
+  webFooters: unknown;
+  webHeaderActions: unknown;
+  webGitTabs: unknown;
+}
+
+export interface SessionStateDTO extends Omit<SessionStateProjectionInput, "model"> {
+  model: SimplifiedModelDTO | undefined;
+}

--- a/server/session/projection.ts
+++ b/server/session/projection.ts
@@ -1,0 +1,453 @@
+import type {
+  ConversationTreeDTO,
+  ConversationTreeNodeDTO,
+  MessageEntryRefDTO,
+  SessionStateDTO,
+  SessionStateProjectionInput,
+  SessionStatsDTO,
+  SimplifiedMessageDTO,
+  SimplifiedModelDTO,
+} from "./dto.js";
+
+export type ToolCallArgumentMap = ReadonlyMap<string, Record<string, unknown>>;
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return value && typeof value === "object" ? value as UnknownRecord : undefined;
+}
+
+export function textFromContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content.map((part) => {
+    const value = asRecord(part);
+    if (!value) return "";
+    if (value.type === "text" && typeof value.text === "string") return value.text;
+    if (value.type === "image") return "[image]";
+    // toolCall parts are rendered as tool cards in the UI — omit from text
+    return "";
+  }).filter(Boolean).join("\n");
+}
+
+export function simplifyModel(model: unknown): SimplifiedModelDTO | undefined {
+  if (!model) return undefined;
+  const value = model as UnknownRecord;
+  return {
+    provider: value.provider,
+    id: value.id,
+    name: value.name || value.id,
+    reasoning: Boolean(value.reasoning),
+    contextWindow: value.contextWindow,
+    maxTokens: value.maxTokens,
+  };
+}
+
+export function hasUserMessages(messages: readonly unknown[]): boolean {
+  return messages.some((message) => asRecord(message)?.role === "user");
+}
+
+function appendMessageEntryRef(refs: MessageEntryRefDTO[], entry: unknown) {
+  const value = asRecord(entry);
+  if (!value) return;
+  if (value.type === "message" || value.type === "custom_message" || value.type === "branch_summary" && value.summary) {
+    const entryId = typeof value.id === "string" && value.id.trim() ? value.id : undefined;
+    refs.push({ entryId });
+  }
+}
+
+/** Projects a session-manager branch without accessing the manager itself. */
+export function messageEntryRefs(branch: readonly unknown[]): MessageEntryRefDTO[] {
+  const refs: MessageEntryRefDTO[] = [];
+  let compaction: UnknownRecord | undefined;
+  for (const entry of branch) {
+    const value = asRecord(entry);
+    if (value?.type === "compaction") compaction = value;
+  }
+
+  if (!compaction) {
+    for (const entry of branch) appendMessageEntryRef(refs, entry);
+    return refs;
+  }
+
+  const compactionId = typeof compaction.id === "string" && compaction.id.trim() ? compaction.id : undefined;
+  refs.push({ entryId: compactionId });
+  const compactionIndex = branch.findIndex((entry) => asRecord(entry)?.type === "compaction" && asRecord(entry)?.id === compaction.id);
+  let foundFirstKept = false;
+  for (let index = 0; index < compactionIndex; index += 1) {
+    const entry = asRecord(branch[index]);
+    if (entry?.id === compaction.firstKeptEntryId) foundFirstKept = true;
+    if (foundFirstKept) appendMessageEntryRef(refs, entry);
+  }
+  for (let index = compactionIndex + 1; index < branch.length; index += 1) appendMessageEntryRef(refs, branch[index]);
+  return refs;
+}
+
+function assistantHttpErrorStatus(code: string) {
+  return code in assistantHttpErrorLabels || /^[45]\d\d$/.test(code);
+}
+
+const assistantHttpErrorLabels: Record<string, string> = {
+  "429": "Throttling error",
+  "500": "Server error",
+  "502": "Bad gateway",
+  "503": "Service unavailable",
+  "504": "Gateway timeout",
+  "529": "Overloaded",
+};
+
+function assistantStatusLabel(label: string | undefined, code: string) {
+  const clean = (label || "").replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+  if (!clean || /^(?:http|status|error|request failed|model request failed)$/i.test(clean)) return assistantHttpErrorLabels[code] || `HTTP ${code}`;
+  return clean;
+}
+
+function assistantStatusErrorPreview(text: string) {
+  const labelled = text.match(/^([A-Za-z][A-Za-z0-9 _/-]*?):\s*(\d{3})(?=$|[\s:,-])/);
+  if (labelled && assistantHttpErrorStatus(labelled[2])) return `${assistantStatusLabel(labelled[1], labelled[2])} (${labelled[2]})`;
+  const leading = text.match(/^(?:HTTP\s*)?(\d{3})(?=$|[\s:,-])/i);
+  if (leading && assistantHttpErrorStatus(leading[1])) return `${assistantStatusLabel(undefined, leading[1])} (${leading[1]})`;
+  const generic = text.match(/^(Error|Request failed|Model request failed)\s*:?\s*(\d{3})(?=$|[\s:,-])/i);
+  if (generic && assistantHttpErrorStatus(generic[2])) return `${assistantStatusLabel(generic[1], generic[2])} (${generic[2]})`;
+  return "";
+}
+
+function assistantParsedErrorDetail(parsed: unknown) {
+  if (typeof parsed === "string") return parsed.trim();
+  const value = asRecord(parsed);
+  if (!value) return "";
+  if (value.error && typeof value.error === "object") {
+    const error = value.error as UnknownRecord;
+    return error.message || error.type || "";
+  }
+  return value.message || value.detail || value.error_description || "";
+}
+
+function assistantJsonErrorPreview(text: string) {
+  const trimmed = text.trim();
+  if (!((trimmed.startsWith("{") && trimmed.endsWith("}")) || (trimmed.startsWith("[") && trimmed.endsWith("]")))) return "";
+  try {
+    const detail = assistantParsedErrorDetail(JSON.parse(trimmed));
+    return detail ? `Error: ${detail}` : "";
+  } catch {
+    return "";
+  }
+}
+
+export function assistantErrorPreview(message: unknown) {
+  const raw = String(asRecord(message)?.errorMessage || "").trim();
+  if (!raw) return "";
+  const jsonText = raw.replace(/^Codex error:\s*/i, "").trim();
+  return assistantJsonErrorPreview(jsonText)
+    || assistantStatusErrorPreview(jsonText)
+    || assistantStatusErrorPreview(raw)
+    || (raw.length > 180 ? `${raw.slice(0, 179)}…` : raw);
+}
+
+export function assistantStopReasonPreview(message: unknown) {
+  const reason = String(asRecord(message)?.stopReason || "").trim();
+  if (!reason || reason === "stop" || reason === "toolUse") return "";
+  if (reason === "length") return "Response stopped because the model hit its output length limit.";
+  if (reason === "aborted") return "Response was aborted.";
+  return `Response stopped unexpectedly: ${reason}`;
+}
+
+/** The input may already contain host-derived fields such as tool startedAt. */
+export function simplifyMessage(message: unknown, toolCallArgs?: ToolCallArgumentMap, entryId?: string): SimplifiedMessageDTO | unknown {
+  const value = asRecord(message);
+  if (!value) return message;
+  const entry = entryId ? { entryId } : {};
+  if (value.role === "bashExecution") {
+    return {
+      ...entry,
+      role: "bashExecution",
+      command: value.command,
+      output: value.output,
+      exitCode: value.exitCode,
+      cancelled: Boolean(value.cancelled),
+      truncated: Boolean(value.truncated),
+      fullOutputPath: value.fullOutputPath,
+      excludeFromContext: Boolean(value.excludeFromContext),
+      timestamp: value.timestamp,
+      raw: value,
+    };
+  }
+  if (value.role === "toolResult") {
+    const toolCallId = value.toolCallId;
+    const args = toolCallArgs?.get(toolCallId as string);
+    return {
+      ...entry,
+      role: "toolResult",
+      toolCallId,
+      toolName: value.toolName,
+      toolArgs: args,
+      isError: Boolean(value.isError),
+      text: textFromContent(value.content),
+      timestamp: value.timestamp,
+      raw: value,
+    };
+  }
+  const text = textFromContent(value.content);
+  const errorText = value.role === "assistant" && value.errorMessage ? assistantErrorPreview(value) : "";
+  const stopReasonText = value.role === "assistant" && !errorText ? assistantStopReasonPreview(value) : "";
+  const displayText = errorText || (text && stopReasonText ? `${text}\n\n${stopReasonText}` : stopReasonText || text);
+  const toolCalls = value.role === "assistant" && Array.isArray(value.content)
+    ? value.content.filter((part) => asRecord(part)?.type === "toolCall").map((part) => {
+      const toolCall = asRecord(part)!;
+      return {
+        id: toolCall.id,
+        toolName: toolCall.toolName || toolCall.name || "tool",
+        args: toolCall.arguments || toolCall.args || {},
+        startedAt: toolCall.startedAt,
+      };
+    })
+    : undefined;
+  return {
+    ...entry,
+    role: value.role,
+    text: displayText,
+    toolCalls,
+    isError: Boolean(value.errorMessage || value.stopReason === "error" || stopReasonText),
+    timestamp: value.timestamp,
+    raw: value,
+  };
+}
+
+function truncatePreview(value: string, max = 220) {
+  const text = value.replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+function entryMessage(entry: unknown): UnknownRecord | undefined {
+  const value = asRecord(entry);
+  if (value?.type === "message") return asRecord(value.message);
+  if (value?.type === "custom_message") return { role: "custom", content: value.content, timestamp: value.timestamp };
+  return undefined;
+}
+
+function messageToolCalls(message: unknown): UnknownRecord[] {
+  const content = asRecord(message)?.content;
+  return Array.isArray(content) ? content.filter((part): part is UnknownRecord => asRecord(part)?.type === "toolCall") : [];
+}
+
+function toolCallName(part: UnknownRecord) {
+  return String(part.toolName || part.name || "tool");
+}
+
+function toolCallArgs(part: UnknownRecord): Record<string, unknown> {
+  const args = part.arguments || part.args;
+  return args && typeof args === "object" ? args as Record<string, unknown> : {};
+}
+
+function shortArg(value: unknown, max = 90) {
+  const text = typeof value === "string" ? value : JSON.stringify(value ?? "");
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+function toolCallPreview(part: UnknownRecord) {
+  const name = toolCallName(part);
+  const args = toolCallArgs(part);
+  if (name === "bash" && typeof args.command === "string") return `Tool call: bash ${shortArg(args.command, 120)}`;
+  if (typeof args.path === "string") return `Tool call: ${name} ${shortArg(args.path, 120)}`;
+  if (typeof args.query === "string") return `Tool call: ${name} ${shortArg(args.query, 120)}`;
+  if (typeof args.pattern === "string") return `Tool call: ${name} ${shortArg(args.pattern, 120)}`;
+  const first = Object.entries(args).find(([, value]) => typeof value === "string" || typeof value === "number" || typeof value === "boolean");
+  return first ? `Tool call: ${name} ${first[0]}=${shortArg(first[1], 90)}` : `Tool call: ${name}`;
+}
+
+function toolCallsPreview(message: unknown) {
+  const calls = messageToolCalls(message);
+  if (calls.length === 0) return "";
+  const [first] = calls;
+  const suffix = calls.length > 1 ? ` + ${calls.length - 1} more` : "";
+  return `${toolCallPreview(first)}${suffix}`;
+}
+
+function messageTextPreview(message: unknown) {
+  return textFromContent(asRecord(message)?.content || "");
+}
+
+function entryRole(entry: unknown) {
+  const message = entryMessage(entry);
+  if (message?.role === "assistant" && !messageTextPreview(message).trim()) {
+    if (messageToolCalls(message).length > 0) return "toolCall";
+    if (message.errorMessage || assistantStopReasonPreview(message)) return "error";
+  }
+  if (message?.role) return String(message.role);
+  switch (asRecord(entry)?.type) {
+    case "branch_summary": return "branchSummary";
+    case "compaction": return "compaction";
+    case "model_change": return "model";
+    case "thinking_level_change": return "thinking";
+    case "session_info": return "session";
+    case "label": return "label";
+    case "custom": return "custom";
+    default: return String(asRecord(entry)?.type || "entry");
+  }
+}
+
+function entryPreview(entry: unknown): string {
+  const value = asRecord(entry);
+  const message = entryMessage(entry);
+  if (message) {
+    if (message.role === "toolResult") {
+      const text = textFromContent(message.content);
+      return `Tool result: ${message.toolName || "tool"}${text ? ` — ${text}` : ""}`;
+    }
+    const text = messageTextPreview(message);
+    if (text.trim()) return text;
+    const calls = toolCallsPreview(message);
+    if (calls) return calls;
+    const error = assistantErrorPreview(message);
+    if (error) return error;
+    const stopReason = assistantStopReasonPreview(message);
+    if (stopReason) return stopReason;
+    return message.role === "assistant" ? "Empty assistant message" : `${message.role || "Message"} message`;
+  }
+  switch (value?.type) {
+    case "branch_summary": return value.summary as string || "Branch summary";
+    case "compaction": return value.summary as string || "Compaction summary";
+    case "model_change": return `Model changed to ${value.provider || "provider"}/${value.modelId || "model"}`;
+    case "thinking_level_change": return `Thinking level changed to ${value.thinkingLevel || "unknown"}`;
+    case "session_info": return value.name ? `Session named ${value.name}` : "Session name cleared";
+    case "label": return value.label ? `Label ${value.targetId || "entry"} as ${value.label}` : `Clear label on ${value.targetId || "entry"}`;
+    case "custom": return `Custom entry${value.customType ? `: ${value.customType}` : ""}`;
+    default: return String(value?.type || "Entry");
+  }
+}
+
+function simpleTreeNode(node: unknown, activePathIds: ReadonlySet<string>, leafId: string | null, childCount: number): ConversationTreeNodeDTO {
+  const nodeValue = asRecord(node);
+  const entry = asRecord(nodeValue?.entry) || nodeValue;
+  const id = String(entry?.id || "");
+  return {
+    id,
+    parentId: typeof entry?.parentId === "string" ? entry.parentId : null,
+    type: String(entry?.type || "entry"),
+    role: entryRole(entry),
+    preview: truncatePreview(entryPreview(entry)),
+    timestamp: String(entry?.timestamp || ""),
+    label: typeof nodeValue?.label === "string" ? nodeValue.label : undefined,
+    labelTimestamp: typeof nodeValue?.labelTimestamp === "string" ? nodeValue.labelTimestamp : undefined,
+    childCount,
+    isOnActivePath: activePathIds.has(id),
+    isCurrentLeaf: Boolean(leafId && id === leafId),
+    children: [],
+  };
+}
+
+function simplifyTreeNodesFlat(roots: readonly unknown[], activePathIds: ReadonlySet<string>, leafId: string | null): ConversationTreeNodeDTO[] {
+  const nodes: ConversationTreeNodeDTO[] = [];
+  const stack = [...roots].reverse();
+  while (stack.length > 0) {
+    const node = stack.pop();
+    const children = Array.isArray(asRecord(node)?.children) ? asRecord(node)!.children as unknown[] : [];
+    nodes.push(simpleTreeNode(node, activePathIds, leafId, children.length));
+    for (let index = children.length - 1; index >= 0; index -= 1) stack.push(children[index]);
+  }
+  return nodes;
+}
+
+export function projectConversationTree(input: { sessionId: string; roots: readonly unknown[]; leafId: string | null; activePath: readonly unknown[] }): ConversationTreeDTO {
+  const activePathIds = new Set(input.activePath.map((entry) => String(asRecord(entry)?.id || "")).filter(Boolean));
+  const nodes = simplifyTreeNodesFlat(input.roots, activePathIds, input.leafId);
+  return {
+    ok: true,
+    sessionId: input.sessionId,
+    leafId: input.leafId,
+    activePathIds: Array.from(activePathIds),
+    entryCount: nodes.length,
+    branchPointCount: nodes.filter((node) => node.childCount > 1).length,
+    nodes,
+  };
+}
+
+export function messageRole(message: unknown) {
+  const value = asRecord(message);
+  return String(value?.role || asRecord(value?.raw)?.role || "");
+}
+
+export function messageStopReason(message: unknown) {
+  const value = asRecord(message);
+  return String(value?.stopReason || asRecord(value?.raw)?.stopReason || "");
+}
+
+export function messageErrorText(message: unknown) {
+  const value = asRecord(message);
+  return typeof value?.errorMessage === "string"
+    ? value.errorMessage
+    : typeof asRecord(value?.raw)?.errorMessage === "string"
+      ? asRecord(value?.raw)!.errorMessage as string
+      : "";
+}
+
+export function isAssistantFailureMessage(message: unknown) {
+  return messageRole(message) === "assistant" && (messageStopReason(message) === "error" || Boolean(messageErrorText(message).trim()));
+}
+
+export function isAssistantAbortedMessage(message: unknown) {
+  return messageRole(message) === "assistant" && messageStopReason(message) === "aborted";
+}
+
+export function isIncompleteToolResultMessage(message: unknown) {
+  return messageRole(message) === "toolResult";
+}
+
+function finiteNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function projectSessionStats(entries: readonly unknown[], contextUsage: unknown): SessionStatsDTO {
+  let input = 0;
+  let output = 0;
+  let cacheRead = 0;
+  let cacheWrite = 0;
+  let cost = 0;
+  let userMessages = 0;
+  let assistantMessages = 0;
+  let toolResults = 0;
+
+  for (const message of entries) {
+    const value = asRecord(message);
+    if (!value) continue;
+    if (value.role === "user") userMessages++;
+    if (value.role === "toolResult") toolResults++;
+    if (value.role !== "assistant") continue;
+    assistantMessages++;
+    const usage = asRecord(value.usage) || {};
+    input += finiteNumber(usage.input);
+    output += finiteNumber(usage.output);
+    cacheRead += finiteNumber(usage.cacheRead);
+    cacheWrite += finiteNumber(usage.cacheWrite);
+    const usageCost = asRecord(usage.cost) || {};
+    const totalCost = finiteNumber(usageCost.total);
+    cost += totalCost || finiteNumber(usageCost.input) + finiteNumber(usageCost.output) + finiteNumber(usageCost.cacheRead) + finiteNumber(usageCost.cacheWrite);
+  }
+
+  return {
+    userMessages,
+    assistantMessages,
+    toolResults,
+    totalMessages: entries.length,
+    tokens: { input, output, cacheRead, cacheWrite, total: input + output + cacheRead + cacheWrite },
+    cost,
+    contextUsage,
+  };
+}
+
+export function projectSessionTitle(sessionName: string | undefined, messages: readonly unknown[]): string {
+  if (sessionName) return sessionName;
+  for (const message of messages) {
+    const value = asRecord(message);
+    const text = textFromContent(value?.content).trim();
+    if (value?.role === "user" && text) return truncatePreview(text, 80);
+  }
+  return "New session";
+}
+
+export function projectSessionState(input: SessionStateProjectionInput): SessionStateDTO {
+  return {
+    ...input,
+    model: simplifyModel(input.model),
+  };
+}

--- a/tests/session-projection.test.ts
+++ b/tests/session-projection.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasUserMessages,
+  isAssistantAbortedMessage,
+  isAssistantFailureMessage,
+  isIncompleteToolResultMessage,
+  messageEntryRefs,
+  projectConversationTree,
+  projectSessionState,
+  projectSessionStats,
+  projectSessionTitle,
+  simplifyMessage,
+  simplifyModel,
+  textFromContent,
+} from "../server/session/projection.js";
+
+function jsonRoundTrip<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+describe("session projections", () => {
+  it("projects text and model DTOs through JSON", () => {
+    expect(textFromContent([{ type: "text", text: "hello" }, { type: "image" }, { type: "toolCall", toolName: "bash" }])).toBe("hello\n[image]");
+    expect(hasUserMessages([{ role: "assistant" }, { role: "user" }])).toBe(true);
+    expect(jsonRoundTrip(simplifyModel({ provider: "openai", id: "gpt", reasoning: 1, contextWindow: 128_000 }))).toEqual({
+      provider: "openai",
+      id: "gpt",
+      name: "gpt",
+      reasoning: true,
+      contextWindow: 128_000,
+    });
+  });
+
+  it("keeps the compaction summary and only its retained message entry refs", () => {
+    const refs = messageEntryRefs([
+      { id: "discarded", type: "message" },
+      { id: "kept", type: "message" },
+      { id: "compact", type: "compaction", firstKeptEntryId: "kept" },
+      { id: "summary", type: "branch_summary", summary: "summary" },
+      { id: "later", type: "custom_message" },
+    ]);
+    expect(jsonRoundTrip(refs)).toEqual([{ entryId: "compact" }, { entryId: "kept" }, { entryId: "summary" }, { entryId: "later" }]);
+  });
+
+  it("simplifies decorated messages without depending on host runtime state", () => {
+    const toolCallArgs = new Map([["call-1", { command: "pwd" }]]);
+    const assistant = simplifyMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Running" }, { type: "toolCall", id: "call-1", toolName: "bash", arguments: { command: "pwd" }, startedAt: "2026-01-01T00:00:00.000Z" }],
+      timestamp: "2026-01-01T00:00:01.000Z",
+    }, toolCallArgs, "entry-1");
+    const toolResult = simplifyMessage({ role: "toolResult", toolCallId: "call-1", toolName: "bash", content: "workspace" }, toolCallArgs);
+
+    expect(jsonRoundTrip(assistant)).toMatchObject({
+      entryId: "entry-1",
+      role: "assistant",
+      text: "Running",
+      toolCalls: [{ id: "call-1", toolName: "bash", args: { command: "pwd" }, startedAt: "2026-01-01T00:00:00.000Z" }],
+    });
+    expect(jsonRoundTrip(toolResult)).toMatchObject({ role: "toolResult", toolArgs: { command: "pwd" }, text: "workspace" });
+  });
+
+  it("projects conversation previews and preserves their JSON DTO shape", () => {
+    const tree = projectConversationTree({
+      sessionId: "session-1",
+      leafId: "tool",
+      activePath: [{ id: "user" }, { id: "tool" }],
+      roots: [{ entry: { id: "user", type: "message", timestamp: "t1", message: { role: "user", content: "A question" } }, children: [
+        { entry: { id: "tool", parentId: "user", type: "message", timestamp: "t2", message: { role: "assistant", content: [{ type: "toolCall", toolName: "bash", arguments: { command: "pwd" } }] } }, children: [] },
+      ] }],
+    });
+
+    expect(jsonRoundTrip(tree)).toMatchObject({
+      ok: true,
+      sessionId: "session-1",
+      activePathIds: ["user", "tool"],
+      entryCount: 2,
+      nodes: [
+        { id: "user", role: "user", preview: "A question", childCount: 1, isOnActivePath: true },
+        { id: "tool", role: "toolCall", preview: "Tool call: bash pwd", isCurrentLeaf: true },
+      ],
+    });
+  });
+
+  it("classifies messages and projects stats and state as JSON", () => {
+    expect(isAssistantFailureMessage({ role: "assistant", errorMessage: "HTTP 429" })).toBe(true);
+    expect(isAssistantAbortedMessage({ role: "assistant", stopReason: "aborted" })).toBe(true);
+    expect(isIncompleteToolResultMessage({ role: "toolResult" })).toBe(true);
+
+    const stats = projectSessionStats([
+      { role: "user" },
+      { role: "assistant", usage: { input: 10, output: 5, cacheRead: 2, cacheWrite: 1, cost: { input: 0.1, output: 0.2 } } },
+      { role: "toolResult" },
+    ], { tokens: 18, contextWindow: 100, percent: 18 });
+    expect(projectSessionTitle(undefined, [{ role: "user", content: "A useful title" }])).toBe("A useful title");
+
+    expect(jsonRoundTrip(projectSessionState({
+      cwd: "/repo",
+      sessionFile: "/repo/.pi/session.jsonl",
+      sessionId: "session-1",
+      sessionName: undefined,
+      sessionTitle: "A useful title",
+      isStreaming: false,
+      isRetrying: false,
+      isCompacting: false,
+      runtimeStartedAt: undefined,
+      runtimeLastActivityAt: undefined,
+      runtime: { loaded: true, isRunning: false },
+      model: { provider: "openai", id: "gpt" },
+      thinkingLevel: "medium",
+      stats,
+      webFooters: [],
+      webHeaderActions: [],
+      webGitTabs: [],
+    }))).toMatchObject({
+      cwd: "/repo",
+      model: { provider: "openai", id: "gpt", name: "gpt", reasoning: false },
+      stats: { userMessages: 1, assistantMessages: 1, toolResults: 1, tokens: { total: 18 }, cost: 0.30000000000000004 },
+    });
+  });
+});


### PR DESCRIPTION
## Stage 2b of the runtime parity refactor

Extracts pure JSON-serializable session projections:
- model/text/message DTOs
- compaction-aware message entry IDs
- conversation tree previews
- retry message classifiers
- session title/stats/state projections

Host-derived activity/tool timestamps remain outside projection logic. Singleton default-session coupling is removed from extracted callers.

Validation: typecheck, projection round-trip tests, full unit/E2E suite, build, diff check.
