### PR TITLE
Extract extension web UI service

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -15,8 +15,6 @@ import {
   getAgentDir,
   ModelRegistry,
   SessionManager,
-  type ExtensionUIDialogOptions,
-  type ExtensionUIContext,
   type SessionStartEvent,
   type SlashCommandInfo,
 } from "@earendil-works/pi-coding-agent";
@@ -27,10 +25,10 @@ import { createSettingsStore } from "./server/settings.js";
 import { artifactDirForCwd, legacyArtifactDirForCwd, safeArtifactName } from "./server/shared/artifacts.js";
 import { assertDirectory, createDirectory, listDirectories } from "./server/shared/fsList.js";
 import { gitCommitDetails, gitCwdFromRepoParam, gitDiff, gitImageBase64, gitLog, gitStatus, gitSync, isGitRepo, listGitRepos } from "./server/shared/git.js";
-import type { PiWebFooter, PiWebGitTab, PiWebHeaderAction, PiWebUi } from "./src/extensions.js";
 import type { PiWebSession } from "./server/types.js";
 import { RealtimeHub, UnreadEventBookkeeper, ViewerLeaseBookkeeper, type RealtimeSocket } from "./server/realtime.js";
 import { SessionActivityTracker } from "./server/session/activity.js";
+import { WebUiExtensionService, cleanWebUiKey, type WebUiSession } from "./server/extensions/webUi.js";
 import {
   hasUserMessages,
   isAssistantAbortedMessage,
@@ -544,9 +542,9 @@ function currentState(targetSession: PiWebSession) {
     model: targetSession.model,
     thinkingLevel: targetSession.thinkingLevel,
     stats: sessionStats(targetSession),
-    webFooters: webFooterEntries(targetSession),
-    webHeaderActions: webHeaderActionEntries(targetSession),
-    webGitTabs: webGitTabEntries(targetSession),
+    webFooters: webUi.footerEntries(targetSession),
+    webHeaderActions: webUi.headerActionEntries(targetSession),
+    webGitTabs: webUi.gitTabEntries(targetSession),
   });
 }
 
@@ -866,374 +864,16 @@ function clearSessionUnread(sessionId: string) {
   broadcastSessionUiStateUpdate(sessionUiStateStore.markRead(sessionId), "Could not clear session unread state:");
 }
 
-const plainExtensionTheme = {
-  fg: (_color: string, text: string) => text,
-  bg: (_color: string, text: string) => text,
-  bold: (text: string) => text,
-  italic: (text: string) => text,
-  underline: (text: string) => text,
-  inverse: (text: string) => text,
-  strikethrough: (text: string) => text,
-  getFgAnsi: () => "",
-  getBgAnsi: () => "",
-  getColorMode: () => "truecolor",
-  getThinkingBorderColor: () => (text: string) => text,
-  getBashModeBorderColor: () => (text: string) => text,
-};
-
-type PendingExtensionUiRequest = {
-  resolve: (response: Record<string, unknown>) => void;
-  cleanup: () => void;
-};
-const pendingExtensionUiRequests = new Map<string, PendingExtensionUiRequest>();
-
-type WebFooterState = {
-  footers: Map<string, PiWebFooter>;
-};
-
-type WebHeaderActionState = {
-  actions: Map<string, PiWebHeaderAction>;
-};
-
-type WebGitTabState = {
-  tabs: Map<string, PiWebGitTab>;
-};
-
-const webFooterStates = new WeakMap<object, WebFooterState>();
-const webHeaderActionStates = new WeakMap<object, WebHeaderActionState>();
-const webGitTabStates = new WeakMap<object, WebGitTabState>();
-
-function getWebFooterState(value: any): WebFooterState {
-  const key = value as object;
-  let state = webFooterStates.get(key);
-  if (!state) {
-    state = { footers: new Map() };
-    webFooterStates.set(key, state);
-  }
-  return state;
-}
-
-function cleanFooterKey(value: unknown) {
-  if (typeof value !== "string") return undefined;
-  const cleaned = value.trim().slice(0, 80).replace(/[^a-zA-Z0-9_.:-]/g, "-");
-  return cleaned || undefined;
-}
-
-const cleanHeaderActionKey = cleanFooterKey;
-const cleanGitTabKey = cleanFooterKey;
-
-function cleanHeaderActionText(value: unknown, maxLength = 200) {
-  if (typeof value !== "string") return undefined;
-  const cleaned = value.replace(/[\u0000-\u001F\u007F]/g, "").trim();
-  return cleaned ? cleaned.slice(0, maxLength) : undefined;
-}
-
-function getWebHeaderActionState(value: any): WebHeaderActionState {
-  const key = value as object;
-  let state = webHeaderActionStates.get(key);
-  if (!state) {
-    state = { actions: new Map() };
-    webHeaderActionStates.set(key, state);
-  }
-  return state;
-}
-
-function getWebGitTabState(value: any): WebGitTabState {
-  const key = value as object;
-  let state = webGitTabStates.get(key);
-  if (!state) {
-    state = { tabs: new Map() };
-    webGitTabStates.set(key, state);
-  }
-  return state;
-}
-
-function cleanFooterText(value: unknown, maxLength = 2_000) {
-  if (typeof value !== "string") return undefined;
-  const cleaned = value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "").trimEnd();
-  return cleaned ? cleaned.slice(0, maxLength) : undefined;
-}
-
-function normalizeTextLines(value: unknown) {
-  const rawLines = Array.isArray(value) ? value : typeof value === "string" ? [value] : [];
-  const lines = rawLines.slice(0, 8).map((line) => cleanFooterText(line)).filter((line): line is string => Boolean(line));
-  return lines.length ? { kind: "text" as const, lines } : undefined;
-}
-
-function normalizePiWebFooter(value: unknown): PiWebFooter | undefined {
-  if (typeof value === "string" || Array.isArray(value)) return normalizeTextLines(value);
-  if (!value || typeof value !== "object") return undefined;
-  const footer = value as Record<string, unknown>;
-  if (footer.kind === "text") return normalizeTextLines(footer.lines);
-  if (footer.kind === "html") {
-    const html = cleanFooterText(footer.html, 20_000);
-    return html ? { kind: "html", html } : undefined;
-  }
-  return undefined;
-}
-
-function webFooterEntries(value: any) {
-  return Array.from(getWebFooterState(value).footers.entries()).map(([key, footer]) => ({ key, footer }));
-}
-
-function broadcastWebFooters(value: any) {
-  const webFooters = webFooterEntries(value);
-  broadcast({
-    type: "web_footer_changed",
-    sessionId: value.sessionId,
-    sessionFile: value.sessionFile,
-    webFooters,
-  });
-  return webFooters;
-}
-
-function webHeaderActionEntries(value: any) {
-  return Array.from(getWebHeaderActionState(value).actions.entries()).map(([key, action]) => ({
-    key,
-    icon: cleanHeaderActionText(action.icon, 80),
-    title: cleanHeaderActionText(action.title) || key,
-    label: cleanHeaderActionText(action.label),
-  }));
-}
-
-function broadcastWebHeaderActions(value: any) {
-  const webHeaderActions = webHeaderActionEntries(value);
-  broadcast({
-    type: "web_header_actions_changed",
-    sessionId: value.sessionId,
-    sessionFile: value.sessionFile,
-    webHeaderActions,
-  });
-  return webHeaderActions;
-}
-
-function webGitTabEntries(value: any) {
-  return Array.from(getWebGitTabState(value).tabs.entries()).map(([key, tab]) => ({
-    key,
-    title: cleanHeaderActionText(tab.title) || key,
-    label: cleanHeaderActionText(tab.label, 80),
-  }));
-}
-
-function broadcastWebGitTabs(value: any) {
-  const webGitTabs = webGitTabEntries(value);
-  broadcast({
-    type: "web_git_tabs_changed",
-    sessionId: value.sessionId,
-    sessionFile: value.sessionFile,
-    webGitTabs,
-  });
-  return webGitTabs;
-}
-
-function createPiWebUi(value: any): PiWebUi {
-  return {
-    setFooter(key, footer) {
-      const footerKey = cleanFooterKey(key);
-      if (!footerKey) return;
-      const footerState = getWebFooterState(value);
-      const normalized = normalizePiWebFooter(footer);
-      if (normalized) footerState.footers.set(footerKey, normalized);
-      else footerState.footers.delete(footerKey);
-      broadcastWebFooters(value);
-    },
-    setHeaderAction(key, action) {
-      const actionKey = cleanHeaderActionKey(key);
-      if (!actionKey) return;
-      const actionState = getWebHeaderActionState(value);
-      if (action && typeof action === "object" && typeof action.invoke === "function") {
-        actionState.actions.set(actionKey, action);
-      } else {
-        actionState.actions.delete(actionKey);
-      }
-      broadcastWebHeaderActions(value);
-    },
-    setGitTab(key, tab) {
-      const tabKey = cleanGitTabKey(key);
-      if (!tabKey) return;
-      const tabState = getWebGitTabState(value);
-      if (tab && typeof tab === "object" && typeof tab.render === "function") {
-        tabState.tabs.set(tabKey, tab);
-      } else {
-        tabState.tabs.delete(tabKey);
-      }
-      broadcastWebGitTabs(value);
-    },
-  };
-}
-
-function broadcastExtensionUiRequest(value: any, method: string, payload: Record<string, unknown>) {
-  const id = randomUUID();
-  broadcast({
-    type: "extension_ui_request",
-    id,
-    method,
-    sessionId: value.sessionId,
-    sessionFile: value.sessionFile,
-    ...payload,
-  });
-  return id;
-}
-
-function requestExtensionUi<T>(
-  value: any,
-  method: string,
-  payload: Record<string, unknown>,
-  opts: ExtensionUIDialogOptions | undefined,
-  defaultValue: T,
-  parse: (response: Record<string, unknown>) => T,
-): Promise<T> {
-  if (opts?.signal?.aborted || realtime.clientCount === 0) return Promise.resolve(defaultValue);
-
-  return new Promise<T>((resolvePromise) => {
-    const id = randomUUID();
-    const releaseWorkLease = acquireWorkLease(value);
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-    const cleanup = () => {
-      if (timeoutId) clearTimeout(timeoutId);
-      opts?.signal?.removeEventListener("abort", onAbort);
-      pendingExtensionUiRequests.delete(id);
-      releaseWorkLease();
-    };
-    const finish = (result: T) => {
-      cleanup();
-      resolvePromise(result);
-    };
-    const onAbort = () => finish(defaultValue);
-
-    opts?.signal?.addEventListener("abort", onAbort, { once: true });
-    if (opts?.timeout) timeoutId = setTimeout(() => finish(defaultValue), opts.timeout);
-
-    pendingExtensionUiRequests.set(id, {
-      cleanup,
-      resolve: (response) => finish(parse(response)),
-    });
-
-    broadcast({
-      type: "extension_ui_request",
-      id,
-      method,
-      sessionId: value.sessionId,
-      sessionFile: value.sessionFile,
-      timeout: opts?.timeout,
-      ...payload,
-    });
-  });
-}
-
-function createWebExtensionUiContext(value: any): ExtensionUIContext & { web: PiWebUi } {
-  return {
-    web: createPiWebUi(value),
-    select: (title, options, opts) => requestExtensionUi(
-      value,
-      "select",
-      { title, options },
-      opts,
-      undefined,
-      (response) => response.cancelled ? undefined : typeof response.value === "string" ? response.value : undefined,
-    ),
-    confirm: (title, message, opts) => requestExtensionUi(
-      value,
-      "confirm",
-      { title, message },
-      opts,
-      false,
-      (response) => response.cancelled ? false : Boolean(response.confirmed),
-    ),
-    input: (title, placeholder, opts) => requestExtensionUi(
-      value,
-      "input",
-      { title, placeholder },
-      opts,
-      undefined,
-      (response) => response.cancelled ? undefined : typeof response.value === "string" ? response.value : undefined,
-    ),
-    notify(message, type = "info") {
-      broadcastExtensionUiRequest(value, "notify", { message, notifyType: type });
-    },
-    onTerminalInput: () => () => undefined,
-    setStatus(key, text) {
-      broadcastExtensionUiRequest(value, "setStatus", { statusKey: key, statusText: text });
-    },
-    setWorkingMessage: () => undefined,
-    setWorkingVisible: () => undefined,
-    setWorkingIndicator: () => undefined,
-    setHiddenThinkingLabel: () => undefined,
-    setWidget(key, content, options) {
-      if (content === undefined || Array.isArray(content)) {
-        broadcastExtensionUiRequest(value, "setWidget", { widgetKey: key, widgetLines: content, widgetPlacement: options?.placement });
-      }
-    },
-    setFooter: () => undefined,
-    setHeader: () => undefined,
-    setTitle(title) {
-      broadcastExtensionUiRequest(value, "setTitle", { title });
-    },
-    async custom() {
-      return undefined as never;
-    },
-    pasteToEditor(text) {
-      this.setEditorText(text);
-    },
-    setEditorText(text) {
-      broadcastExtensionUiRequest(value, "set_editor_text", { text });
-    },
-    getEditorText: () => "",
-    editor: (title, prefill) => requestExtensionUi(
-      value,
-      "editor",
-      { title, prefill },
-      undefined,
-      undefined,
-      (response) => response.cancelled ? undefined : typeof response.value === "string" ? response.value : undefined,
-    ),
-    addAutocompleteProvider: () => undefined,
-    setEditorComponent: () => undefined,
-    getEditorComponent: () => undefined,
-    theme: plainExtensionTheme as any,
-    getAllThemes: () => [],
-    getTheme: () => undefined,
-    setTheme: () => ({ success: false, error: "Theme switching is not supported in pi-web yet" }),
-    getToolsExpanded: () => false,
-    setToolsExpanded: () => undefined,
-  };
-}
-
-async function bindWebExtensions(value: any) {
-  if (typeof value.bindExtensions !== "function") return;
-  await value.bindExtensions({
-    uiContext: createWebExtensionUiContext(value),
-    commandContextActions: {
-      waitForIdle: () => value.agent.waitForIdle(),
-      newSession: async () => {
-        const newSession = await createNewLiveSession(sessionCwd(value), value.sessionFile);
-        const state = currentStateWithThinkingLevels(newSession);
-        broadcast({ type: "state_changed", ...state });
-        return { cancelled: false };
-      },
-      fork: async () => {
-        throw new Error("Extension-initiated fork is not supported in pi-web yet.");
-      },
-      navigateTree: async (targetId: string, options: any) => {
-        const result = await value.navigateTree(targetId, options);
-        return { cancelled: Boolean(result?.cancelled) };
-      },
-      switchSession: async () => {
-        throw new Error("Extension-initiated session switching is not supported in pi-web yet.");
-      },
-      reload: async () => {
-        await value.reload?.();
-      },
-    },
-    shutdownHandler: () => {
-      broadcast({ type: "server_error", sessionId: value.sessionId, sessionFile: value.sessionFile, error: "An extension requested shutdown; pi-web ignored the request." });
-    },
-    onError: (error: any) => {
-      broadcast({ type: "server_error", sessionId: value.sessionId, sessionFile: value.sessionFile, error: `Extension error (${error.extensionPath}): ${error.error}` });
-    },
-  });
-}
+// Browser transport remains a thin adapter around serializable extension UI service events.
+const webUi: WebUiExtensionService = new WebUiExtensionService({
+  broadcast,
+  emitExtensionUiEvent: (event) => broadcast(event),
+  clientCount: () => realtime.clientCount,
+  acquireWorkLease: (value) => acquireWorkLease(value),
+  sessionCwd: (value) => sessionCwd(value as unknown as PiWebSession),
+  createNewSession: async (cwd, previousSessionFile) => createNewLiveSession(cwd, previousSessionFile) as unknown as WebUiSession,
+  currentStateWithThinkingLevels: (value) => currentStateWithThinkingLevels(value as unknown as PiWebSession),
+}, randomUUID);
 
 const mockHarness = createMockHarness({
   piCwd,
@@ -1471,7 +1111,7 @@ async function makeAgentSession(path?: string, sessionStartEvent?: SessionStartE
     resourceLoader: loader,
     sessionStartEvent,
   });
-  await bindWebExtensions(result.session);
+  await webUi.bindWebExtensions(result.session as unknown as WebUiSession);
   return result;
 }
 
@@ -1717,15 +1357,13 @@ const server = createServer(async (req, res) => {
         const requestedSessionId = typeof body.sessionId === "string" ? body.sessionId : session.sessionId;
         const targetSession = requestedSessionId === session.sessionId ? session : await getOrCreateLiveSessionById(requestedSessionId);
         if (!targetSession) return sendJson(res, 404, { ok: false, error: "Session not found" });
-        const actionKey = cleanHeaderActionKey(body.key);
+        const actionKey = cleanWebUiKey(body.key);
         if (!actionKey) return sendJson(res, 400, { ok: false, error: "key is required" });
-        const action = getWebHeaderActionState(targetSession).actions.get(actionKey);
-        if (!action) return sendJson(res, 404, { ok: false, error: "Header action not found" });
+        if (!webUi.hasHeaderAction(targetSession, actionKey)) return sendJson(res, 404, { ok: false, error: "Header action not found" });
         try {
-          const result = await action.invoke();
-          const markdown = cleanFooterText(result?.markdown, 200_000);
-          if (!markdown) return sendJson(res, 400, { ok: false, error: "Header action returned no markdown" });
-          return sendJson(res, 200, { ok: true, label: cleanHeaderActionText(action.label) || cleanHeaderActionText(action.title) || actionKey, markdown });
+          const result = await webUi.invokeHeaderAction(targetSession, actionKey);
+          if (!result) return sendJson(res, 400, { ok: false, error: "Header action returned no markdown" });
+          return sendJson(res, 200, { ok: true, ...result });
         } catch (error) {
           return sendJson(res, 500, { ok: false, error: error instanceof Error ? error.message : String(error) });
         }
@@ -1736,13 +1374,12 @@ const server = createServer(async (req, res) => {
         const requestedSessionId = typeof body.sessionId === "string" ? body.sessionId : session.sessionId;
         const targetSession = requestedSessionId === session.sessionId ? session : await getOrCreateLiveSessionById(requestedSessionId);
         if (!targetSession) return sendJson(res, 404, { ok: false, error: "Session not found" });
-        const tabKey = cleanGitTabKey(body.key);
+        const tabKey = cleanWebUiKey(body.key);
         if (!tabKey) return sendJson(res, 400, { ok: false, error: "key is required" });
-        const tab = getWebGitTabState(targetSession).tabs.get(tabKey);
-        if (!tab) return sendJson(res, 404, { ok: false, error: "Git tab not found" });
+        if (!webUi.hasGitTab(targetSession, tabKey)) return sendJson(res, 404, { ok: false, error: "Git tab not found" });
         try {
           const repo = body.repo && typeof body.repo === "object" ? body.repo as Record<string, unknown> : undefined;
-          const result = await tab.render({
+          const result = await webUi.invokeGitTab(targetSession, tabKey, {
             action: typeof body.action === "string" ? body.action : undefined,
             payload: body.payload,
             repo: repo ? {
@@ -1751,9 +1388,8 @@ const server = createServer(async (req, res) => {
               branch: typeof repo.branch === "string" ? repo.branch : undefined,
             } : undefined,
           });
-          const html = cleanFooterText(result?.html, 500_000);
-          if (!html) return sendJson(res, 400, { ok: false, error: "Git tab returned no HTML" });
-          return sendJson(res, 200, { ok: true, title: cleanHeaderActionText(result?.title) || cleanHeaderActionText(tab.title) || tabKey, html });
+          if (!result) return sendJson(res, 400, { ok: false, error: "Git tab returned no HTML" });
+          return sendJson(res, 200, { ok: true, ...result });
         } catch (error) {
           return sendJson(res, 500, { ok: false, error: error instanceof Error ? error.message : String(error) });
         }
@@ -1965,9 +1601,7 @@ const server = createServer(async (req, res) => {
         const body = await readBody(req) as { id?: unknown } & Record<string, unknown>;
         const id = String(body.id || "").trim();
         if (!id) return sendJson(res, 400, { ok: false, error: "id is required" });
-        const pending = pendingExtensionUiRequests.get(id);
-        if (!pending) return sendJson(res, 404, { ok: false, error: "Extension UI request not found" });
-        pending.resolve(body);
+        if (!webUi.respondExtensionUi({ ...body, id })) return sendJson(res, 404, { ok: false, error: "Extension UI request not found" });
         return sendJson(res, 200, { ok: true });
       }
 

--- a/server/extensions/webUi.ts
+++ b/server/extensions/webUi.ts
@@ -1,0 +1,353 @@
+import type { ExtensionUIDialogOptions, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import type { PiWebFooter, PiWebGitTab, PiWebGitTabEvent, PiWebHeaderAction, PiWebUi } from "../../src/extensions.js";
+
+export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue | undefined };
+
+export type ExtensionUiMethod = "select" | "confirm" | "input" | "notify" | "setStatus" | "setWidget" | "setTitle" | "set_editor_text" | "editor";
+
+/** Serializable request emitted for browser adapters or future service transports. */
+export interface ExtensionUiServiceEvent {
+  type: "extension_ui_request";
+  id: string;
+  method: ExtensionUiMethod;
+  sessionId: string;
+  sessionFile: string;
+  timeout?: number;
+  [key: string]: JsonValue | undefined;
+}
+
+export interface ExtensionUiResponse {
+  id: string;
+  cancelled?: boolean;
+  confirmed?: boolean;
+  value?: JsonValue;
+  [key: string]: JsonValue | undefined;
+}
+
+export interface WebUiSession {
+  sessionId: string;
+  sessionFile: string;
+  agent: { waitForIdle(): Promise<unknown> };
+  bindExtensions?(bindings: unknown): Promise<void>;
+  navigateTree(targetId: string, options?: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string }): Promise<{ cancelled: boolean }>;
+  reload?(): Promise<void>;
+}
+
+export interface WebUiHost {
+  broadcast(value: unknown): void;
+  emitExtensionUiEvent(event: ExtensionUiServiceEvent): void;
+  clientCount(): number;
+  acquireWorkLease(session: WebUiSession): () => void;
+  sessionCwd(session: WebUiSession): string;
+  createNewSession(cwd: string, previousSessionFile: string): Promise<WebUiSession>;
+  currentStateWithThinkingLevels(session: WebUiSession): Record<string, unknown>;
+}
+
+export interface WebFooterProjection {
+  key: string;
+  footer: Exclude<PiWebFooter, string | string[]>;
+}
+
+export interface WebHeaderActionProjection {
+  key: string;
+  icon?: string;
+  title: string;
+  label?: string;
+}
+
+export interface WebGitTabProjection {
+  key: string;
+  title: string;
+  label?: string;
+}
+
+type PendingExtensionUiRequest = {
+  resolve: (response: ExtensionUiResponse) => void;
+  cleanup: () => void;
+};
+
+type FooterState = { footers: Map<string, Exclude<PiWebFooter, string | string[]>> };
+type HeaderActionState = { actions: Map<string, PiWebHeaderAction> };
+type GitTabState = { tabs: Map<string, PiWebGitTab> };
+
+const plainExtensionTheme = {
+  fg: (_color: string, text: string) => text,
+  bg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+  italic: (text: string) => text,
+  underline: (text: string) => text,
+  inverse: (text: string) => text,
+  strikethrough: (text: string) => text,
+  getFgAnsi: () => "",
+  getBgAnsi: () => "",
+  getColorMode: () => "truecolor",
+  getThinkingBorderColor: () => (text: string) => text,
+  getBashModeBorderColor: () => (text: string) => text,
+};
+
+function cleanKey(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const cleaned = value.trim().slice(0, 80).replace(/[^a-zA-Z0-9_.:-]/g, "-");
+  return cleaned || undefined;
+}
+
+function cleanText(value: unknown, maxLength = 200): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const cleaned = value.replace(/[\u0000-\u001F\u007F]/g, "").trim();
+  return cleaned ? cleaned.slice(0, maxLength) : undefined;
+}
+
+function cleanFooterText(value: unknown, maxLength = 2_000): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const cleaned = value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "").trimEnd();
+  return cleaned ? cleaned.slice(0, maxLength) : undefined;
+}
+
+function normalizeTextLines(value: unknown): Exclude<PiWebFooter, string | string[]> | undefined {
+  const rawLines = Array.isArray(value) ? value : typeof value === "string" ? [value] : [];
+  const lines = rawLines.slice(0, 8).map((line) => cleanFooterText(line)).filter((line): line is string => Boolean(line));
+  return lines.length ? { kind: "text", lines } : undefined;
+}
+
+function normalizeFooter(value: unknown): Exclude<PiWebFooter, string | string[]> | undefined {
+  if (typeof value === "string" || Array.isArray(value)) return normalizeTextLines(value);
+  if (!value || typeof value !== "object") return undefined;
+  const footer = value as Record<string, unknown>;
+  if (footer.kind === "text") return normalizeTextLines(footer.lines);
+  if (footer.kind === "html") {
+    const html = cleanFooterText(footer.html, 20_000);
+    return html ? { kind: "html", html } : undefined;
+  }
+  return undefined;
+}
+
+function asResponse(value: unknown): ExtensionUiResponse | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const response = value as Record<string, JsonValue | undefined>;
+  return typeof response.id === "string" && response.id.trim() ? response as ExtensionUiResponse : undefined;
+}
+
+export class WebUiExtensionService {
+  private readonly pendingRequests = new Map<string, PendingExtensionUiRequest>();
+  private readonly footerStates = new WeakMap<object, FooterState>();
+  private readonly headerActionStates = new WeakMap<object, HeaderActionState>();
+  private readonly gitTabStates = new WeakMap<object, GitTabState>();
+
+  constructor(private readonly host: WebUiHost, private readonly createId: () => string) {}
+
+  footerEntries(session: object): WebFooterProjection[] {
+    return Array.from(this.footerState(session).footers, ([key, footer]) => ({ key, footer }));
+  }
+
+  headerActionEntries(session: object): WebHeaderActionProjection[] {
+    return Array.from(this.headerActionState(session).actions, ([key, action]) => ({
+      key,
+      icon: cleanText(action.icon, 80),
+      title: cleanText(action.title) || key,
+      label: cleanText(action.label),
+    }));
+  }
+
+  gitTabEntries(session: object): WebGitTabProjection[] {
+    return Array.from(this.gitTabState(session).tabs, ([key, tab]) => ({
+      key,
+      title: cleanText(tab.title) || key,
+      label: cleanText(tab.label, 80),
+    }));
+  }
+
+  createPiWebUi(session: WebUiSession): PiWebUi {
+    return {
+      setFooter: (key, footer) => {
+        const footerKey = cleanKey(key);
+        if (!footerKey) return;
+        const normalized = normalizeFooter(footer);
+        if (normalized) this.footerState(session).footers.set(footerKey, normalized);
+        else this.footerState(session).footers.delete(footerKey);
+        this.host.broadcast({ type: "web_footer_changed", sessionId: session.sessionId, sessionFile: session.sessionFile, webFooters: this.footerEntries(session) });
+      },
+      setHeaderAction: (key, action) => {
+        const actionKey = cleanKey(key);
+        if (!actionKey) return;
+        if (action && typeof action === "object" && typeof action.invoke === "function") this.headerActionState(session).actions.set(actionKey, action);
+        else this.headerActionState(session).actions.delete(actionKey);
+        this.host.broadcast({ type: "web_header_actions_changed", sessionId: session.sessionId, sessionFile: session.sessionFile, webHeaderActions: this.headerActionEntries(session) });
+      },
+      setGitTab: (key, tab) => {
+        const tabKey = cleanKey(key);
+        if (!tabKey) return;
+        if (tab && typeof tab === "object" && typeof tab.render === "function") this.gitTabState(session).tabs.set(tabKey, tab);
+        else this.gitTabState(session).tabs.delete(tabKey);
+        this.host.broadcast({ type: "web_git_tabs_changed", sessionId: session.sessionId, sessionFile: session.sessionFile, webGitTabs: this.gitTabEntries(session) });
+      },
+    };
+  }
+
+  respondExtensionUi(response: unknown): boolean {
+    const parsed = asResponse(response);
+    if (!parsed) return false;
+    const pending = this.pendingRequests.get(parsed.id.trim());
+    if (!pending) return false;
+    pending.resolve(parsed);
+    return true;
+  }
+
+  hasHeaderAction(session: object, key: string): boolean {
+    return this.headerActionState(session).actions.has(key);
+  }
+
+  hasGitTab(session: object, key: string): boolean {
+    return this.gitTabState(session).tabs.has(key);
+  }
+
+  async invokeHeaderAction(session: object, key: string): Promise<{ label: string; markdown: string } | undefined> {
+    const action = this.headerActionState(session).actions.get(key);
+    if (!action) return undefined;
+    const result = await action.invoke();
+    const markdown = cleanFooterText(result?.markdown, 200_000);
+    if (!markdown) return undefined;
+    return { label: cleanText(action.label) || cleanText(action.title) || key, markdown };
+  }
+
+  async invokeGitTab(session: object, key: string, event: PiWebGitTabEvent): Promise<{ title: string; html: string } | undefined> {
+    const tab = this.gitTabState(session).tabs.get(key);
+    if (!tab) return undefined;
+    const result = await tab.render(event);
+    const html = cleanFooterText(result?.html, 500_000);
+    if (!html) return undefined;
+    return { title: cleanText(result.title) || cleanText(tab.title) || key, html };
+  }
+
+  async bindWebExtensions(session: WebUiSession) {
+    if (typeof session.bindExtensions !== "function") return;
+    await session.bindExtensions({
+      uiContext: this.createExtensionUiContext(session),
+      commandContextActions: {
+        waitForIdle: () => session.agent.waitForIdle(),
+        newSession: async () => {
+          const newSession = await this.host.createNewSession(this.host.sessionCwd(session), session.sessionFile);
+          this.host.broadcast({ type: "state_changed", ...this.host.currentStateWithThinkingLevels(newSession) });
+          return { cancelled: false };
+        },
+        fork: async () => {
+          throw new Error("Extension-initiated fork is not supported in pi-web yet.");
+        },
+        navigateTree: async (targetId: string, options: { summarize?: boolean; customInstructions?: string; replaceInstructions?: boolean; label?: string }) => {
+          const result = await session.navigateTree(targetId, options);
+          return { cancelled: Boolean(result.cancelled) };
+        },
+        switchSession: async () => {
+          throw new Error("Extension-initiated session switching is not supported in pi-web yet.");
+        },
+        reload: async () => {
+          await session.reload?.();
+        },
+      },
+      shutdownHandler: () => {
+        this.host.broadcast({ type: "server_error", sessionId: session.sessionId, sessionFile: session.sessionFile, error: "An extension requested shutdown; pi-web ignored the request." });
+      },
+      onError: (error: { extensionPath?: unknown; error?: unknown }) => {
+        this.host.broadcast({ type: "server_error", sessionId: session.sessionId, sessionFile: session.sessionFile, error: `Extension error (${error.extensionPath}): ${error.error}` });
+      },
+    });
+  }
+
+  private createExtensionUiContext(session: WebUiSession): ExtensionUIContext & { web: PiWebUi } {
+    return {
+      web: this.createPiWebUi(session),
+      select: (title, options, opts) => this.request(session, "select", { title, options: options as JsonValue }, opts, undefined, (response) => response.cancelled ? undefined : typeof response.value === "string" ? response.value : undefined),
+      confirm: (title, message, opts) => this.request(session, "confirm", { title, message }, opts, false, (response) => response.cancelled ? false : Boolean(response.confirmed)),
+      input: (title, placeholder, opts) => this.request(session, "input", { title, placeholder }, opts, undefined, (response) => response.cancelled ? undefined : typeof response.value === "string" ? response.value : undefined),
+      notify: (message, type = "info") => this.emit(session, "notify", { message, notifyType: type }),
+      onTerminalInput: () => () => undefined,
+      setStatus: (key, text) => this.emit(session, "setStatus", { statusKey: key, statusText: text }),
+      setWorkingMessage: () => undefined,
+      setWorkingVisible: () => undefined,
+      setWorkingIndicator: () => undefined,
+      setHiddenThinkingLabel: () => undefined,
+      setWidget: (key, content, options) => {
+        if (content === undefined || Array.isArray(content)) this.emit(session, "setWidget", { widgetKey: key, widgetLines: content as JsonValue | undefined, widgetPlacement: options?.placement });
+      },
+      setFooter: () => undefined,
+      setHeader: () => undefined,
+      setTitle: (title) => this.emit(session, "setTitle", { title }),
+      async custom() {
+        return undefined as never;
+      },
+      pasteToEditor(text) {
+        this.setEditorText(text);
+      },
+      setEditorText: (text) => this.emit(session, "set_editor_text", { text }),
+      getEditorText: () => "",
+      editor: (title, prefill) => this.request(session, "editor", { title, prefill }, undefined, undefined, (response) => response.cancelled ? undefined : typeof response.value === "string" ? response.value : undefined),
+      addAutocompleteProvider: () => undefined,
+      setEditorComponent: () => undefined,
+      getEditorComponent: () => undefined,
+      theme: plainExtensionTheme as unknown as ExtensionUIContext["theme"],
+      getAllThemes: () => [],
+      getTheme: () => undefined,
+      setTheme: () => ({ success: false, error: "Theme switching is not supported in pi-web yet" }),
+      getToolsExpanded: () => false,
+      setToolsExpanded: () => undefined,
+    };
+  }
+
+  private emit(session: WebUiSession, method: ExtensionUiMethod, fields: Record<string, JsonValue | undefined>) {
+    this.host.emitExtensionUiEvent({ type: "extension_ui_request", id: this.createId(), method, sessionId: session.sessionId, sessionFile: session.sessionFile, ...fields });
+  }
+
+  private request<T>(session: WebUiSession, method: ExtensionUiMethod, fields: Record<string, JsonValue | undefined>, opts: ExtensionUIDialogOptions | undefined, defaultValue: T, parse: (response: ExtensionUiResponse) => T): Promise<T> {
+    if (opts?.signal?.aborted || this.host.clientCount() === 0) return Promise.resolve(defaultValue);
+    return new Promise<T>((resolvePromise) => {
+      const id = this.createId();
+      const releaseWorkLease = this.host.acquireWorkLease(session);
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const cleanup = () => {
+        if (timeoutId) clearTimeout(timeoutId);
+        opts?.signal?.removeEventListener("abort", onAbort);
+        this.pendingRequests.delete(id);
+        releaseWorkLease();
+      };
+      const finish = (result: T) => {
+        cleanup();
+        resolvePromise(result);
+      };
+      const onAbort = () => finish(defaultValue);
+      opts?.signal?.addEventListener("abort", onAbort, { once: true });
+      if (opts?.timeout) timeoutId = setTimeout(() => finish(defaultValue), opts.timeout);
+      this.pendingRequests.set(id, { cleanup, resolve: (response) => finish(parse(response)) });
+      this.host.emitExtensionUiEvent({ type: "extension_ui_request", id, method, sessionId: session.sessionId, sessionFile: session.sessionFile, timeout: opts?.timeout, ...fields });
+    });
+  }
+
+  private footerState(session: object): FooterState {
+    let state = this.footerStates.get(session);
+    if (!state) {
+      state = { footers: new Map() };
+      this.footerStates.set(session, state);
+    }
+    return state;
+  }
+
+  private headerActionState(session: object): HeaderActionState {
+    let state = this.headerActionStates.get(session);
+    if (!state) {
+      state = { actions: new Map() };
+      this.headerActionStates.set(session, state);
+    }
+    return state;
+  }
+
+  private gitTabState(session: object): GitTabState {
+    let state = this.gitTabStates.get(session);
+    if (!state) {
+      state = { tabs: new Map() };
+      this.gitTabStates.set(session, state);
+    }
+    return state;
+  }
+}
+
+export function cleanWebUiKey(value: unknown): string | undefined {
+  return cleanKey(value);
+}

--- a/tests/web-ui-extension.test.ts
+++ b/tests/web-ui-extension.test.ts
@@ -1,0 +1,75 @@
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { WebUiExtensionService, type ExtensionUiServiceEvent, type WebUiSession } from "../server/extensions/webUi.js";
+import type { PiWebUi } from "../src/extensions.js";
+
+function createHarness() {
+  const broadcasts: unknown[] = [];
+  const requests: ExtensionUiServiceEvent[] = [];
+  let bindings: unknown;
+  const session: WebUiSession = {
+    sessionId: "session-1",
+    sessionFile: "/repo/.pi/session.jsonl",
+    agent: { waitForIdle: async () => undefined },
+    bindExtensions: async (value) => { bindings = value; },
+    navigateTree: async () => ({ cancelled: false }),
+  };
+  let nextId = 0;
+  const service = new WebUiExtensionService({
+    broadcast: (value) => broadcasts.push(value),
+    emitExtensionUiEvent: (event) => requests.push(event),
+    clientCount: () => 1,
+    acquireWorkLease: () => () => undefined,
+    sessionCwd: () => "/repo",
+    createNewSession: async () => session,
+    currentStateWithThinkingLevels: () => ({ sessionId: "session-1" }),
+  }, () => `request-${++nextId}`);
+  return { broadcasts, requests, session, service, getBindings: () => bindings as { uiContext: ExtensionUIContext & { web: PiWebUi } } };
+}
+
+describe("web extension UI service", () => {
+  it("projects footer, header action, and git tab state through JSON", () => {
+    const { broadcasts, session, service } = createHarness();
+    const ui = service.createPiWebUi(session);
+    ui.setFooter("footer key", { kind: "text", lines: ["line one", "line two"] });
+    ui.setHeaderAction("run", { title: "Run extension", label: "Run", invoke: () => ({ markdown: "done" }) });
+    ui.setGitTab("review", { title: "Review", label: "Diff", render: () => ({ html: "<p>review</p>" }) });
+
+    expect(JSON.parse(JSON.stringify(service.footerEntries(session)))).toEqual([
+      { key: "footer-key", footer: { kind: "text", lines: ["line one", "line two"] } },
+    ]);
+    expect(JSON.parse(JSON.stringify(service.headerActionEntries(session)))).toEqual([
+      { key: "run", title: "Run extension", label: "Run" },
+    ]);
+    expect(JSON.parse(JSON.stringify(service.gitTabEntries(session)))).toEqual([
+      { key: "review", title: "Review", label: "Diff" },
+    ]);
+    expect(broadcasts.map((event) => (event as { type: string }).type)).toEqual([
+      "web_footer_changed",
+      "web_header_actions_changed",
+      "web_git_tabs_changed",
+    ]);
+  });
+
+  it("emits serializable dialog requests and resolves explicit responses", async () => {
+    const { requests, service, session, getBindings } = createHarness();
+    await service.bindWebExtensions(session);
+    const ui = getBindings().uiContext;
+    const selected = ui.select("Choose", ["one", "two"]);
+
+    expect(JSON.parse(JSON.stringify(requests))).toEqual([
+      {
+        type: "extension_ui_request",
+        id: "request-1",
+        method: "select",
+        sessionId: "session-1",
+        sessionFile: "/repo/.pi/session.jsonl",
+        title: "Choose",
+        options: ["one", "two"],
+      },
+    ]);
+    expect(service.respondExtensionUi({ id: "missing", value: "one" })).toBe(false);
+    expect(service.respondExtensionUi(JSON.parse(JSON.stringify({ id: "request-1", value: "two" })))).toBe(true);
+    await expect(selected).resolves.toBe("two");
+  });
+});


### PR DESCRIPTION
## Stage 2d of the runtime parity refactor

Extracts extension web UI behavior behind typed serializable events:
- footers, header actions, and Git tabs
- extension UI request/response bookkeeping
- explicit `respondExtensionUi` operation
- extension context creation and binding

This is the inversion needed for extensions loaded from any session runtime to drive the same browser UI.

Validation: typecheck, extension projection/request round-trip tests, full unit/E2E suite, build, diff check.
