### PR TITLE
Characterize SessionService extraction behavior

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1076,7 +1076,11 @@ function additionalExtensionPaths(cwd = piCwd) {
 }
 
 async function makeAgentSession(path?: string, sessionStartEvent?: SessionStartEvent, cwd = piCwd) {
-  if (mockMode) return { session: createMockSession(path), modelFallbackMessage: undefined };
+  if (mockMode) {
+    const session = createMockSession(path);
+    await webUi.bindWebExtensions(session as unknown as WebUiSession);
+    return { session, modelFallbackMessage: undefined };
+  }
 
   const targetCwd = await assertDirectory(cwd);
   const sessionManager = noSession
@@ -1229,7 +1233,9 @@ const server = createServer(async (req, res) => {
         await Promise.all(Array.from(liveSessions.keys()).map((key) => disposeLiveSession(key, "reset", true)));
         resetMockSessions();
         await sessionUiStateStore.write(defaultSessionUiState);
-        session = registerLiveSession(createMockSession());
+        const mockSession = createMockSession();
+        await webUi.bindWebExtensions(mockSession as unknown as WebUiSession);
+        session = registerLiveSession(mockSession);
         broadcast({ type: "session_ui_state_changed", sessionUiState: defaultSessionUiState });
         broadcast({ type: "state_changed", ...currentState(session) });
         return sendJson(res, 200, { ok: true });

--- a/server/mock.ts
+++ b/server/mock.ts
@@ -11,6 +11,9 @@ interface MockSessionOptions {
 export function createMockHarness(options: MockSessionOptions) {
   const { piCwd, broadcast, isCurrentSession, currentState } = options;
   const mockModel = { provider: "mock", id: "model", name: "Mock Model", reasoning: true, contextWindow: 128000, maxTokens: 4096 };
+  // Test-only fixture modes exercise compatibility paths that real sessions need.
+  const legacyRetryMode = process.env.PI_WEB_MOCK_LEGACY_RETRY === "1";
+  const eventTimestampsOnly = process.env.PI_WEB_MOCK_EVENT_TIMESTAMPS_ONLY === "1";
 
   function initialMockSessions(): PiWebSessionInfo[] {
     return [
@@ -105,13 +108,14 @@ export function createMockHarness(options: MockSessionOptions) {
         { type: "message", id: "mock-u-alt", parentId: "mock-u1", timestamp: "2026-05-07T10:02:00Z", message: { role: "user", content: "Actually, make the attachment picker mobile-first.", timestamp: "2026-05-07T10:02:00Z" } },
         { type: "message", id: "mock-a-alt", parentId: "mock-u-alt", timestamp: "2026-05-07T10:03:00Z", message: { role: "assistant", content: "Use a bottom sheet with large tap targets for image actions.", timestamp: "2026-05-07T10:03:00Z" } },
       );
+      if (legacyRetryMode) entries.push({ type: "message", id: "mock-legacy-retry-failure", parentId: "mock-a1", timestamp: "2026-05-07T10:01:30Z", message: { role: "assistant", content: "Legacy retry failure", stopReason: "error", errorMessage: "Legacy retry failure", timestamp: "2026-05-07T10:01:30Z" } });
     }
     return entries;
   }
 
   function createMockSession(path = mockSessions[0].path): PiWebSession {
     let mockEntries = createInitialEntries(path);
-    let mockLeafId: string | null = "mock-a1";
+    let mockLeafId: string | null = legacyRetryMode && path === mockSessions[0].path ? "mock-legacy-retry-failure" : "mock-a1";
     let entrySequence = 2;
     const labelsById = new Map<string, string>();
     const mockMessages: unknown[] = [];
@@ -180,17 +184,20 @@ export function createMockHarness(options: MockSessionOptions) {
     let compactionAbortRequested = false;
     let runtimeStartedAt: string | undefined;
     let runtimeLastActivityAt: string | undefined;
+    let extensionBindings: any;
 
     function setRuntimeStartedAt(startedAt = new Date().toISOString(), lastActivityAt = startedAt) {
       runtimeStartedAt = startedAt;
       runtimeLastActivityAt = lastActivityAt;
-      (mockSession as any).runtimeStartedAt = runtimeStartedAt;
-      (mockSession as any).runtimeLastActivityAt = runtimeLastActivityAt;
+      if (!eventTimestampsOnly) {
+        (mockSession as any).runtimeStartedAt = runtimeStartedAt;
+        (mockSession as any).runtimeLastActivityAt = runtimeLastActivityAt;
+      }
     }
 
     function markRuntimeActivity(activityAt = new Date().toISOString()) {
       runtimeLastActivityAt = activityAt;
-      (mockSession as any).runtimeLastActivityAt = runtimeLastActivityAt;
+      if (!eventTimestampsOnly) (mockSession as any).runtimeLastActivityAt = runtimeLastActivityAt;
       return runtimeLastActivityAt;
     }
 
@@ -319,6 +326,10 @@ export function createMockHarness(options: MockSessionOptions) {
       return removed;
     }
 
+    async function continueLegacyRetry() {
+      appendMockMessage({ role: "assistant", content: "Recovered through legacy retry continuation.", timestamp: new Date().toISOString() });
+    }
+
     async function runMockRetryFromFailure() {
       const lastMessage = mockMessages[mockMessages.length - 1];
       if (isMockAssistantFailure(lastMessage)) branchBeforeTrailingMockMessages(isMockAssistantFailure);
@@ -346,7 +357,7 @@ export function createMockHarness(options: MockSessionOptions) {
       model: mockModel,
       thinkingLevel: "medium",
       messages: mockMessages,
-      agent: { state: { messages: mockMessages } },
+      agent: { state: { messages: mockMessages }, ...(legacyRetryMode ? { continue: continueLegacyRetry } : {}) } as any,
       sessionManager: mockSessionManager,
       modelRegistry: {
         getAvailable: () => [mockModel],
@@ -357,6 +368,10 @@ export function createMockHarness(options: MockSessionOptions) {
           invocationName: "mock-extension",
           description: "Mock extension command",
           sourceInfo: { path: "<mock-extension>", source: "mock", scope: "temporary", origin: "top-level" },
+        }, {
+          name: "mock-named-extension",
+          description: "Mock extension command registered by name",
+          sourceInfo: { path: "<mock-named-extension>", source: "mock", scope: "temporary", origin: "top-level" },
         }],
         hasHandlers: (eventType: string) => eventType === "session_shutdown",
         emit: async (event: { type?: string }) => {
@@ -432,6 +447,7 @@ export function createMockHarness(options: MockSessionOptions) {
         appendMockMessage({ role: "bashExecution", command, ...result, excludeFromContext: Boolean(options?.excludeFromContext), timestamp: new Date().toISOString() });
         return result;
       },
+      bindExtensions: async (bindings: unknown) => { extensionBindings = bindings; },
       prompt: async (message: string, promptOptions?: { images?: unknown[] }) => {
         const runGeneration = mockGeneration;
         const isCurrentMockRun = () => runGeneration === mockGeneration;
@@ -451,6 +467,8 @@ export function createMockHarness(options: MockSessionOptions) {
         }
         const slow = /slow|running/i.test(message);
         const withShowcase = /showcase/i.test(message);
+        const withExtensionUiEvents = /extension ui events/i.test(message);
+        const withExtensionNewSession = /extension new session/i.test(message);
         const withProviderError = /provider error|assistant error|usage limit/i.test(message);
         const withRetryFailure = /retry failure|retry exhausted|throttle failure/i.test(message);
         const withRetrySuccess = !withRetryFailure && /retry demo|retry success|throttle retry/i.test(message);
@@ -475,6 +493,13 @@ export function createMockHarness(options: MockSessionOptions) {
         }
         broadcastRuntimeChanged();
         broadcastPiEvent({ type: "agent_start", startedAt: runtimeStartedAt }, runtimeLastActivityAt || runtimeStartedAt);
+        if (withExtensionUiEvents) {
+          const web = extensionBindings?.uiContext?.web;
+          web?.setFooter("mock-footer", { kind: "text", lines: ["Mock extension footer"] });
+          web?.setHeaderAction("mock-header", { title: "Mock header action", label: "Mock action", invoke: () => ({ markdown: "Mock header result" }) });
+          web?.setGitTab("mock-git", { title: "Mock Git tab", label: "Mock Git", render: () => ({ html: "<p>Mock extension Git tab</p>" }) });
+        }
+        if (withExtensionNewSession) await extensionBindings?.commandContextActions?.newSession?.();
         if (withQuietRuntime) {
           if (!(await waitForMockRun(60_000))) return;
         } else if (slow && !(await waitForMockRun(750))) return;
@@ -647,7 +672,7 @@ export function createMockHarness(options: MockSessionOptions) {
           });
         }
       },
-      retryFromFailure: async () => runMockRetryFromFailure(),
+      ...(legacyRetryMode ? {} : { retryFromFailure: async () => runMockRetryFromFailure() }),
       abort: async () => { mockSession.isStreaming = false; mockSession.isRetrying = false; clearRuntimeTimestamps(); broadcastRuntimeChanged(); },
       abortCompaction: () => { compactionAbortRequested = true; },
       clearQueue: () => undefined,

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -74,7 +74,7 @@ describe("pi-web mock API", () => {
     const port = await freePort();
     baseUrl = `http://127.0.0.1:${port}`;
     child = spawn(process.execPath, ["--import", "tsx", "server.ts"], {
-      env: { ...process.env, PI_WEB_MOCK: "1", PI_WEB_DEV: "1", HOST: "127.0.0.1", PORT: String(port), PI_WEB_TOKEN: "", PI_WEB_SETTINGS_FILE: join(settingsDir, "settings.json"), PI_WEB_SESSION_UI_STATE_FILE: join(settingsDir, "session-ui-state.json") },
+      env: { ...process.env, PI_WEB_MOCK: "1", PI_WEB_MOCK_EVENT_TIMESTAMPS_ONLY: "1", PI_WEB_DEV: "1", HOST: "127.0.0.1", PORT: String(port), PI_WEB_TOKEN: "", PI_WEB_SETTINGS_FILE: join(settingsDir, "settings.json"), PI_WEB_SESSION_UI_STATE_FILE: join(settingsDir, "session-ui-state.json") },
       stdio: ["ignore", "pipe", "pipe"],
     });
     child.stderr?.on("data", (data) => process.stderr.write(data));
@@ -101,6 +101,68 @@ describe("pi-web mock API", () => {
     const sessions = await (await fetch(`${baseUrl}/api/sessions`)).json();
     expect(sessions.sessions).toHaveLength(2);
     expect(sessions.sessions.every((item: any) => item.isCurrent === false)).toBe(true);
+  });
+
+  it("keeps the original route-default session after creating another session", async () => {
+    await fetch(`${baseUrl}/api/mock/reset`, { method: "POST" });
+    const initial = await (await fetch(`${baseUrl}/api/state`)).json();
+    const created = await (await fetch(`${baseUrl}/api/sessions/new`, { method: "POST" })).json();
+    expect(created.sessionId).not.toBe(initial.sessionId);
+    expect((await (await fetch(`${baseUrl}/api/state`)).json()).sessionId).toBe(initial.sessionId);
+    await fetch(`${baseUrl}/api/mock/reset`, { method: "POST" });
+  });
+
+  it("decorates both state timestamp forms from session activity events", async () => {
+    await fetch(`${baseUrl}/api/mock/reset`, { method: "POST" });
+    void fetch(`${baseUrl}/api/prompt`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "slow timestamp characterization" }),
+    });
+    await waitForCondition(async () => {
+      const state = await (await fetch(`${baseUrl}/api/state`)).json();
+      return Boolean(state.runtime?.isRunning && state.runtimeStartedAt && state.runtimeLastActivityAt && state.runtime?.startedAt && state.runtime?.lastActivityAt);
+    });
+    const state = await (await fetch(`${baseUrl}/api/state`)).json();
+    expect(state.runtimeStartedAt).toBe(state.runtime.startedAt);
+    expect(state.runtimeLastActivityAt).toBe(state.runtime.lastActivityAt);
+    await fetch(`${baseUrl}/api/abort`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+    await fetch(`${baseUrl}/api/mock/reset`, { method: "POST" });
+  });
+
+  it("forwards dynamic extension UI events and complete state_changed payloads", async () => {
+    await fetch(`${baseUrl}/api/mock/reset`, { method: "POST" });
+    const events: Array<Record<string, unknown>> = [];
+    const ws = new WebSocket(`ws://127.0.0.1:${new URL(baseUrl).port}/ws`);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        ws.once("message", (data) => {
+          const event = JSON.parse(String(data)) as Record<string, unknown>;
+          events.push(event);
+          event.type === "hello" ? resolve() : reject(new Error("Expected websocket hello"));
+        });
+        ws.once("error", reject);
+      });
+      ws.on("message", (data) => events.push(JSON.parse(String(data)) as Record<string, unknown>));
+      const prompt = await fetch(`${baseUrl}/api/prompt`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ message: "extension ui events extension new session" }),
+      });
+      expect(prompt.status).toBe(202);
+      await waitForCondition(() => ["web_footer_changed", "web_header_actions_changed", "web_git_tabs_changed"].every((type) => events.some((event) => event.type === type)));
+      await waitForCondition(() => events.some((event) => event.type === "state_changed"));
+
+      expect(events.find((event) => event.type === "web_footer_changed")).toMatchObject({ sessionId: "mock-current", webFooters: [{ key: "mock-footer" }] });
+      expect(events.find((event) => event.type === "web_header_actions_changed")).toMatchObject({ sessionId: "mock-current", webHeaderActions: [{ key: "mock-header" }] });
+      expect(events.find((event) => event.type === "web_git_tabs_changed")).toMatchObject({ sessionId: "mock-current", webGitTabs: [{ key: "mock-git" }] });
+      const stateChanges = events.filter((event) => event.type === "state_changed");
+      expect(stateChanges.length).toBeGreaterThan(0);
+      expect(stateChanges.every((event) => typeof event.sessionId === "string" && typeof event.sessionFile === "string")).toBe(true);
+    } finally {
+      ws.terminate();
+      await fetch(`${baseUrl}/api/mock/reset`, { method: "POST" });
+    }
   });
 
   it("deletes a requested session", async () => {
@@ -364,6 +426,13 @@ describe("pi-web mock API", () => {
       body: JSON.stringify({ command: "/does-not-exist" }),
     });
     expect(invalidRes.status).toBe(500);
+
+    const malformedModel = await fetch(`${baseUrl}/api/command`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ command: "/model malformed" }),
+    });
+    expect(malformedModel.status).toBe(500);
   });
 
   it("executes shell commands in the requested session cwd", async () => {
@@ -467,6 +536,39 @@ describe("pi-web mock API", () => {
   });
 });
 
+describe("legacy retry API compatibility", () => {
+  let child: ChildProcess;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const port = await freePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+    child = spawn(process.execPath, ["--import", "tsx", "server.ts"], {
+      env: { ...process.env, PI_WEB_MOCK: "1", PI_WEB_MOCK_LEGACY_RETRY: "1", PI_WEB_DEV: "1", HOST: "127.0.0.1", PORT: String(port), PI_WEB_TOKEN: "" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stderr?.on("data", (data) => process.stderr.write(data));
+    await waitForServer(baseUrl);
+  }, 20_000);
+
+  afterAll(() => child?.kill());
+
+  it("repairs the failed branch and continues when retryFromFailure is unavailable", async () => {
+    const retry = await fetch(`${baseUrl}/api/session/retry`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "mock-current" }),
+    });
+    expect(retry.status).toBe(202);
+    await waitForCondition(async () => {
+      const messages = await (await fetch(`${baseUrl}/api/messages?sessionId=mock-current`)).json();
+      return messages.messages.some((message: { text?: string }) => message.text === "Recovered through legacy retry continuation.");
+    });
+    const messages = await (await fetch(`${baseUrl}/api/messages?sessionId=mock-current`)).json();
+    expect(messages.messages.some((message: { text?: string }) => message.text === "Legacy retry failure")).toBe(false);
+  });
+});
+
 describe("git repo discovery API", () => {
   let child: ChildProcess;
   let baseUrl: string;
@@ -514,6 +616,10 @@ describe("git repo discovery API", () => {
 
     const invalid = await fetch(`${baseUrl}/api/git/status?repo=../repo-b`);
     expect(invalid.status).toBe(400);
+
+    const unknownSession = await fetch(`${baseUrl}/api/git/status?sessionId=does-not-exist&repo=repo-b`);
+    expect(unknownSession.status).toBe(400);
+    expect((await unknownSession.json()).error).toBe("Session not found");
   });
 });
 
@@ -748,6 +854,7 @@ describe("additional API coverage", () => {
     expect(names).toContain("clear");
     expect(names).not.toContain("new-chat");
     expect(names).toContain("mock-extension");
+    expect(names).toContain("mock-named-extension");
     expect(names).toContain("mock-prompt");
     expect(names).toContain("skill:mock-skill");
   });
@@ -827,6 +934,7 @@ describe("Live session lifecycle", () => {
       env: {
         ...process.env,
         PI_WEB_MOCK: "1",
+        PI_WEB_MOCK_EVENT_TIMESTAMPS_ONLY: "1",
         PI_WEB_DEV: "1",
         HOST: "127.0.0.1",
         PORT: String(port),
@@ -882,6 +990,50 @@ describe("Live session lifecycle", () => {
 
     const state = await lifecycleState();
     expect(state.liveSessions.some((item) => item.sessionId === "mock-current")).toBe(true);
+  }, 10_000);
+
+  it("clears host activity maps when an idle session is disposed", async () => {
+    await reset();
+    const opened = await fetch(`${baseUrl}/api/sessions/open`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-pi-web-client-id": "activity-cleanup" },
+      body: JSON.stringify({ sessionId: "mock-older", clientId: "activity-cleanup" }),
+    });
+    expect(opened.status).toBe(200);
+    void fetch(`${baseUrl}/api/prompt`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "mock-older", message: "slow no agent end" }),
+    });
+    await waitForCondition(async () => {
+      const state = await (await fetch(`${baseUrl}/api/state?sessionId=mock-older`)).json();
+      return Boolean(state.runtime?.isRunning && state.runtime?.startedAt);
+    });
+    const first = await (await fetch(`${baseUrl}/api/state?sessionId=mock-older`)).json();
+    const firstStartedAt = first.runtime.startedAt;
+    await waitForCondition(async () => !(await (await fetch(`${baseUrl}/api/state?sessionId=mock-older`)).json()).runtime?.isRunning, 3_000);
+    await waitForCondition(async () => {
+      const state = await lifecycleState();
+      return !state.liveSessions.some((item) => item.sessionId === "mock-older");
+    }, 3_000);
+
+    expect((await fetch(`${baseUrl}/api/sessions/open`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "mock-older" }),
+    })).status).toBe(200);
+    void fetch(`${baseUrl}/api/prompt`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sessionId: "mock-older", message: "slow fresh activity" }),
+    });
+    await waitForCondition(async () => {
+      const state = await (await fetch(`${baseUrl}/api/state?sessionId=mock-older`)).json();
+      return Boolean(state.runtime?.isRunning && state.runtime?.startedAt);
+    });
+    const second = await (await fetch(`${baseUrl}/api/state?sessionId=mock-older`)).json();
+    expect(second.runtime.startedAt).not.toBe(firstStartedAt);
+    await fetch(`${baseUrl}/api/abort`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ sessionId: "mock-older" }) });
   }, 10_000);
 
   it("terminates stale WebSockets with missed heartbeats and releases their session lease", async () => {


### PR DESCRIPTION
## Stage 2e safety ratchet

Adds API-level characterization tests before moving session ownership behind `SessionService`. These cover regressions that a first green-but-invalid extraction exposed:

- dynamic extension footer/header/Git-tab events and complete state events
- retry branch repair without the convenience `retryFromFailure` helper
- explicit unknown-session Git rejection
- top-level and nested runtime activity timestamps
- legacy default/current-session behavior
- extension command discovery by `invocationName` or `name`
- host activity cleanup after session disposal
- slash-command HTTP status contracts

The only production changes bind the existing extension UI context in mock sessions so these compatibility paths can be exercised. No runtime behavior is added.

Validation: typecheck, full unit/E2E suite, build, diff check.
