### PR TITLE
Define the transport-safe SessionService contract

### DIFF
--- a/server/session/api.ts
+++ b/server/session/api.ts
@@ -1,0 +1,505 @@
+import type {
+  ConversationTreeDTO,
+  JsonObject,
+  JsonValue,
+  SessionMessageFactDTO,
+  SessionModelDTO,
+  SessionRuntimeFactDTO,
+  SessionStateFactDTO,
+  SessionStatsFactDTO,
+} from "./dto.js";
+
+export type {
+  JsonObject,
+  JsonValue,
+  SessionMessageFactDTO,
+  SessionModelDTO,
+  SessionRuntimeFactDTO,
+  SessionStateFactDTO,
+  SessionStatsFactDTO,
+} from "./dto.js";
+
+/** Identifies a session without relying on a process-global current session. */
+export interface SessionContext {
+  sessionId: string;
+}
+
+/** The service instance owns this identity; callers do not provide it. */
+export interface ServiceStartDTO {
+  boxId: string;
+}
+
+export interface ServiceErrorDTO {
+  code: string;
+  message: string;
+  status: number;
+}
+
+export interface ServiceSuccess<T> {
+  ok: true;
+  value: T;
+}
+
+export interface ServiceFailure {
+  ok: false;
+  error: ServiceErrorDTO;
+}
+
+export type ServiceResult<T> = ServiceSuccess<T> | ServiceFailure;
+
+export interface EmptyDTO {
+  ok: true;
+}
+
+export interface SessionCreateRequest {
+  cwd: string;
+  previousSessionId: string | null;
+}
+
+export interface SessionOpenRequest extends SessionContext {
+  cwd: string | null;
+}
+
+export interface SessionDeleteRequest extends SessionContext {
+  cwd: string | null;
+}
+
+export interface SessionDeleteDTO {
+  sessionId: string;
+  disposition: "trashed" | "deleted";
+}
+
+export interface SessionListRequest {
+  cwds: string[];
+}
+
+export interface SessionSummaryDTO {
+  sessionId: string;
+  name: string;
+  firstMessage: string;
+  createdAt: string;
+  modifiedAt: string;
+  messageCount: number;
+  cwd: string;
+  runtime: SessionRuntimeFactDTO;
+}
+
+export interface SessionSwitchCwdRequest {
+  cwd: string;
+}
+
+export interface SessionCommandsDTO {
+  commands: SlashCommandDTO[];
+}
+
+export interface SlashCommandDTO {
+  name: string;
+  description: string;
+  source: "web" | "extension" | "prompt" | "skill";
+  sourceInfo: JsonObject;
+}
+
+export interface SessionModelsDTO {
+  cwd: string;
+  current: SessionModelDTO | null;
+  thinkingLevel: string;
+  thinkingLevels: string[];
+  models: SessionModelDTO[];
+}
+
+export interface PromptImageDTO {
+  data: string;
+  mimeType: string;
+  name: string | null;
+}
+
+export interface PromptRequest {
+  message: string;
+  mode: "steer" | "followUp";
+  images: PromptImageDTO[];
+}
+
+export interface PromptAcceptedDTO {
+  sessionId: string;
+}
+
+export interface ModelSelectionRequest {
+  provider: string;
+  id: string;
+  thinkingLevel: string | null;
+}
+
+export interface CommandRequest {
+  command: string;
+}
+
+export interface CommandResultDTO {
+  message: string;
+  state: SessionStateFactDTO;
+}
+
+export interface ShellRequest {
+  command: string;
+  excludeFromContext: boolean;
+}
+
+export interface ShellResultDTO {
+  command: string;
+  cwd: string;
+  output: string;
+  exitCode: number | null;
+  cancelled: boolean;
+  truncated: boolean;
+  fullOutputPath: string | null;
+  excludeFromContext: boolean;
+}
+
+export interface TreeNavigationRequest {
+  targetId: string;
+  summarize: boolean;
+  customInstructions: string | null;
+  replaceInstructions: boolean;
+  label: string | null;
+}
+
+export interface TreeNavigationResultDTO {
+  editorText: string | null;
+  cancelled: boolean;
+  aborted: boolean;
+  summaryEntry: JsonValue | null;
+  leafId: string | null;
+  state: SessionStateFactDTO;
+}
+
+export interface ExtensionHeaderActionRequest {
+  key: string;
+}
+
+export interface ExtensionHeaderActionResultDTO {
+  label: string;
+  markdown: string;
+}
+
+export interface ExtensionGitTabRequest {
+  key: string;
+  action: string | null;
+  payload: JsonValue | null;
+  repo: ExtensionGitTabRepoDTO | null;
+}
+
+export interface ExtensionGitTabRepoDTO {
+  path: string | null;
+  root: string | null;
+  branch: string | null;
+}
+
+export interface ExtensionGitTabResultDTO {
+  title: string;
+  html: string;
+}
+
+export type ExtensionUiMethodDTO = "select" | "confirm" | "input" | "notify" | "setStatus" | "setWidget" | "setTitle" | "set_editor_text" | "editor";
+
+/** JSON-only extension dialog request emitted to the browser adapter. */
+export interface ExtensionUiRequestEventDTO extends JsonObject {
+  type: "extension_ui_request";
+  id: string;
+  method: ExtensionUiMethodDTO;
+  sessionId: string;
+  sessionFile: string;
+  timeoutMs: number | null;
+}
+
+/** JSON-only browser response passed back to an extension in the session's box. */
+export interface ExtensionUiResponseDTO extends JsonObject {
+  id: string;
+  cancelled: boolean;
+  confirmed: boolean;
+  value: JsonValue | null;
+}
+
+export interface ExtensionUiResponseResultDTO {
+  accepted: boolean;
+}
+
+export interface ViewerLeaseRequest {
+  clientId: string;
+}
+
+export interface ViewerLeaseDTO {
+  sessionId: string;
+  clientId: string;
+}
+
+export interface DirectoryListRequest {
+  path: string;
+}
+
+export interface DirectoryEntryDTO {
+  name: string;
+  path: string;
+}
+
+export interface DirectoryListingDTO {
+  path: string;
+  parent: string;
+  dirs: DirectoryEntryDTO[];
+}
+
+export interface DirectoryCreateRequest {
+  parent: string;
+  name: string;
+}
+
+export interface ArtifactReadRequest {
+  name: string;
+}
+
+/** Artifact bytes are transport data, never a path on the hosting box. */
+export interface ArtifactBase64DTO {
+  name: string;
+  mimeType: string;
+  base64: string;
+}
+
+export interface ArtifactTextDTO {
+  name: string;
+  mimeType: string;
+  text: string;
+}
+
+export interface ArtifactWriteRequest {
+  name: string;
+  mimeType: string;
+  base64: string;
+}
+
+export interface ArtifactWriteDTO {
+  name: string;
+  mimeType: string;
+  size: number;
+}
+
+export interface GitRepoRefRequest {
+  repo: string | null;
+}
+
+export interface GitRepoSummaryDTO {
+  path: string;
+  root: string;
+  branch: string;
+  upstream: string;
+  ahead: number;
+  behind: number;
+  dirtyCount: number;
+  isCurrent: boolean;
+}
+
+export interface GitReposDTO {
+  cwd: string;
+  depth: number;
+  repos: GitRepoSummaryDTO[];
+}
+
+export interface GitStatusRequest extends GitRepoRefRequest {
+  fetch: boolean;
+}
+
+export interface GitStatusFileDTO {
+  path: string;
+  oldPath: string | null;
+  indexStatus: string;
+  worktreeStatus: string;
+  label: "untracked" | "conflicted" | "renamed" | "added" | "deleted" | "staged" | "modified";
+  staged: boolean;
+}
+
+export interface GitStatusDTO {
+  isRepo: boolean;
+  root: string | null;
+  branch: string | null;
+  upstream: string | null;
+  defaultRemoteBranch: string | null;
+  ahead: number;
+  behind: number;
+  files: GitStatusFileDTO[];
+}
+
+export interface GitCommitRefRequest extends GitRepoRefRequest {
+  hash: string;
+}
+
+export interface GitCommitDTO {
+  hash: string;
+  shortHash: string;
+  parents: string[];
+  author: string;
+  date: string;
+  refs: string[];
+  subject: string;
+}
+
+export interface GitLogDTO {
+  isRepo: boolean;
+  commits: GitCommitDTO[];
+}
+
+export interface GitCommitFileDTO {
+  path: string;
+  status: string;
+  additions: number | null;
+  deletions: number | null;
+}
+
+export interface GitCommitDetailsDTO {
+  commit: GitCommitDTO;
+  files: GitCommitFileDTO[];
+  diff: string;
+}
+
+export interface GitDiffRequest extends GitRepoRefRequest {
+  path: string;
+  staged: boolean;
+}
+
+export interface GitDiffDTO {
+  path: string;
+  staged: boolean;
+  diff: string;
+}
+
+export interface GitImageRequest extends GitRepoRefRequest {
+  path: string;
+  oldPath: string | null;
+  version: "before" | "after";
+  staged: boolean;
+}
+
+export interface GitImageDTO {
+  path: string;
+  base64: string;
+}
+
+export interface GitSyncDTO {
+  output: string;
+  status: GitStatusDTO;
+}
+
+/** Filesystem operations belong to the service's box, not to a session. */
+export interface SessionFilesystemService {
+  list(request: DirectoryListRequest): Promise<ServiceResult<DirectoryListingDTO>>;
+  mkdir(request: DirectoryCreateRequest): Promise<ServiceResult<DirectoryListingDTO>>;
+}
+
+export interface SessionArtifactService {
+  read(context: SessionContext, request: ArtifactReadRequest): Promise<ServiceResult<ArtifactTextDTO>>;
+  readBase64(context: SessionContext, request: ArtifactReadRequest): Promise<ServiceResult<ArtifactBase64DTO>>;
+  write(context: SessionContext, request: ArtifactWriteRequest): Promise<ServiceResult<ArtifactWriteDTO>>;
+}
+
+export interface SessionGitService {
+  repos(context: SessionContext): Promise<ServiceResult<GitReposDTO>>;
+  status(context: SessionContext, request: GitStatusRequest): Promise<ServiceResult<GitStatusDTO>>;
+  log(context: SessionContext, request: GitRepoRefRequest): Promise<ServiceResult<GitLogDTO>>;
+  commit(context: SessionContext, request: GitCommitRefRequest): Promise<ServiceResult<GitCommitDetailsDTO>>;
+  diff(context: SessionContext, request: GitDiffRequest): Promise<ServiceResult<GitDiffDTO>>;
+  image(context: SessionContext, request: GitImageRequest): Promise<ServiceResult<GitImageDTO>>;
+  sync(context: SessionContext, request: GitRepoRefRequest): Promise<ServiceResult<GitSyncDTO>>;
+}
+
+export interface WebFooterDTO {
+  key: string;
+  footer: JsonValue;
+}
+
+export interface WebHeaderActionDTO {
+  key: string;
+  icon: string | null;
+  title: string;
+  label: string | null;
+}
+
+export interface WebGitTabDTO {
+  key: string;
+  title: string;
+  label: string | null;
+}
+
+export type SessionServiceEvent =
+  | { type: "pi_event"; sessionId: string; sessionFile: string; event: JsonValue }
+  | { type: "session_runtime_changed"; sessionId: string; sessionFile: string; runtime: SessionRuntimeFactDTO }
+  | { type: "state_changed"; state: SessionStateFactDTO }
+  | { type: "session_stats_changed"; sessionId: string; sessionFile: string; stats: SessionStatsFactDTO }
+  | { type: "models_updated"; sessionId: string; models: SessionModelDTO[] }
+  | { type: "server_error"; sessionId: string; sessionFile: string; error: ServiceErrorDTO }
+  | { type: "session_shutdown"; sessionId: string; sessionFile: string; reason: "idle" | "delete" | "reset" | "close" }
+  | { type: "web_footer_changed"; sessionId: string; sessionFile: string; webFooters: WebFooterDTO[] }
+  | { type: "web_header_actions_changed"; sessionId: string; sessionFile: string; webHeaderActions: WebHeaderActionDTO[] }
+  | { type: "web_git_tabs_changed"; sessionId: string; sessionFile: string; webGitTabs: WebGitTabDTO[] }
+  | ExtensionUiRequestEventDTO;
+
+/**
+ * Box-local session protocol. All session-scoped methods require an explicit
+ * context; browser route defaults and activity decoration live outside it.
+ */
+export interface SessionService {
+  start(): Promise<ServiceResult<ServiceStartDTO>>;
+  close(): Promise<ServiceResult<EmptyDTO>>;
+  create(request: SessionCreateRequest): Promise<ServiceResult<SessionStateFactDTO>>;
+  open(request: SessionOpenRequest): Promise<ServiceResult<SessionStateFactDTO>>;
+  delete(request: SessionDeleteRequest): Promise<ServiceResult<SessionDeleteDTO>>;
+  list(request: SessionListRequest): Promise<ServiceResult<SessionSummaryDTO[]>>;
+  switchCwd(context: SessionContext, request: SessionSwitchCwdRequest): Promise<ServiceResult<SessionStateFactDTO>>;
+  state(context: SessionContext): Promise<ServiceResult<SessionStateFactDTO>>;
+  messages(context: SessionContext): Promise<ServiceResult<SessionMessageFactDTO[]>>;
+  stats(context: SessionContext): Promise<ServiceResult<SessionStatsFactDTO>>;
+  tree(context: SessionContext): Promise<ServiceResult<ConversationTreeDTO>>;
+  commands(context: SessionContext): Promise<ServiceResult<SessionCommandsDTO>>;
+  models(context: SessionContext): Promise<ServiceResult<SessionModelsDTO>>;
+  prompt(context: SessionContext, request: PromptRequest): Promise<ServiceResult<PromptAcceptedDTO>>;
+  abort(context: SessionContext): Promise<ServiceResult<PromptAcceptedDTO>>;
+  abortCompaction(context: SessionContext): Promise<ServiceResult<PromptAcceptedDTO>>;
+  retry(context: SessionContext): Promise<ServiceResult<PromptAcceptedDTO>>;
+  rename(context: SessionContext, name: string): Promise<ServiceResult<SessionStateFactDTO>>;
+  setModel(context: SessionContext, request: ModelSelectionRequest): Promise<ServiceResult<SessionStateFactDTO>>;
+  executeCommand(context: SessionContext, request: CommandRequest): Promise<ServiceResult<CommandResultDTO>>;
+  executeShell(context: SessionContext, request: ShellRequest): Promise<ServiceResult<ShellResultDTO>>;
+  navigateTree(context: SessionContext, request: TreeNavigationRequest): Promise<ServiceResult<TreeNavigationResultDTO>>;
+  abortBranchSummary(context: SessionContext): Promise<ServiceResult<PromptAcceptedDTO>>;
+  respondExtensionUi(context: SessionContext, response: ExtensionUiResponseDTO): Promise<ServiceResult<ExtensionUiResponseResultDTO>>;
+  hasHeaderAction(context: SessionContext, request: ExtensionHeaderActionRequest): Promise<ServiceResult<boolean>>;
+  invokeHeaderAction(context: SessionContext, request: ExtensionHeaderActionRequest): Promise<ServiceResult<ExtensionHeaderActionResultDTO>>;
+  hasGitTab(context: SessionContext, request: ExtensionHeaderActionRequest): Promise<ServiceResult<boolean>>;
+  invokeGitTab(context: SessionContext, request: ExtensionGitTabRequest): Promise<ServiceResult<ExtensionGitTabResultDTO>>;
+  acquireViewer(context: SessionContext, request: ViewerLeaseRequest): Promise<ServiceResult<ViewerLeaseDTO>>;
+  releaseViewer(context: SessionContext, lease: ViewerLeaseDTO): Promise<ServiceResult<EmptyDTO>>;
+  fs: SessionFilesystemService;
+  artifacts: SessionArtifactService;
+  git: SessionGitService;
+  subscribe(listener: (event: SessionServiceEvent) => void): () => void;
+}
+
+/** Rejects values that JSON.stringify would silently alter or discard. */
+export function assertSessionTransportValue(value: unknown, path = "value"): asserts value is JsonValue {
+  if (value === null || typeof value === "boolean" || typeof value === "string") return;
+  if (typeof value === "number") {
+    if (Number.isFinite(value)) return;
+    throw new TypeError(`${path} must be a finite JSON number`);
+  }
+  if (value === undefined) throw new TypeError(`${path} must not be undefined`);
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertSessionTransportValue(item, `${path}[${index}]`));
+    return;
+  }
+  if (typeof value === "object") {
+    for (const [key, nested] of Object.entries(value)) assertSessionTransportValue(nested, `${path}.${key}`);
+    return;
+  }
+  throw new TypeError(`${path} is not JSON-serializable`);
+}
+
+/** Round-trips protocol values through the same JSON boundary a remote transport uses. */
+export function serializeSessionTransport<T extends JsonValue>(value: T): T {
+  assertSessionTransportValue(value);
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/server/session/dto.ts
+++ b/server/session/dto.ts
@@ -1,10 +1,27 @@
+/** Values that can cross a SessionService process boundary without adaptation. */
+export type JsonPrimitive = null | boolean | number | string;
+export type JsonValue = JsonPrimitive | JsonValue[] | JsonObject;
+export interface JsonObject { [key: string]: JsonValue }
+
+/** Browser projection of a model already simplified from the pi runtime. */
 export interface SimplifiedModelDTO {
-  provider: unknown;
-  id: unknown;
-  name: unknown;
+  provider: string;
+  id: string;
+  name: string;
   reasoning: boolean;
-  contextWindow: unknown;
-  maxTokens: unknown;
+  contextWindow?: number;
+  maxTokens?: number;
+}
+
+/** Lossless, box-local model fact carried by the transport protocol. */
+export interface SessionModelDTO {
+  provider: string;
+  id: string;
+  name: string;
+  reasoning: boolean;
+  contextWindow: number | null;
+  maxTokens: number | null;
+  metadata: JsonObject;
 }
 
 export interface MessageEntryRefDTO {
@@ -12,30 +29,40 @@ export interface MessageEntryRefDTO {
 }
 
 export interface SimplifiedToolCallDTO {
-  id: unknown;
-  toolName: unknown;
-  args: unknown;
-  startedAt: unknown;
+  id?: JsonValue;
+  toolName?: JsonValue;
+  args: JsonValue;
+  startedAt?: JsonValue;
 }
 
+/** Existing browser message projection, including host-decorated tool timestamps. */
 export interface SimplifiedMessageDTO {
   entryId?: string;
-  role: unknown;
+  role?: JsonValue;
   text?: string;
   toolCalls?: SimplifiedToolCallDTO[];
   isError?: boolean;
-  timestamp?: unknown;
-  raw: Record<string, unknown>;
-  command?: unknown;
-  output?: unknown;
-  exitCode?: unknown;
+  timestamp?: JsonValue;
+  raw: JsonObject;
+  command?: JsonValue;
+  output?: JsonValue;
+  exitCode?: JsonValue;
   cancelled?: boolean;
   truncated?: boolean;
-  fullOutputPath?: unknown;
+  fullOutputPath?: JsonValue;
   excludeFromContext?: boolean;
-  toolCallId?: unknown;
-  toolName?: unknown;
-  toolArgs?: Record<string, unknown>;
+  toolCallId?: JsonValue;
+  toolName?: JsonValue;
+  toolArgs?: JsonObject;
+}
+
+/** Raw box-local message fact. The host derives activity decoration from pi events. */
+export interface SessionMessageFactDTO {
+  entryId: string | null;
+  role: string;
+  content: JsonValue;
+  timestamp: string | null;
+  attributes: JsonObject;
 }
 
 export interface ConversationTreeNodeDTO {
@@ -76,9 +103,70 @@ export interface SessionStatsDTO {
     total: number;
   };
   cost: number;
-  contextUsage: unknown;
+  contextUsage?: JsonValue;
 }
 
+/** JSON-only stats fact carried by the transport protocol. */
+export interface SessionStatsFactDTO {
+  userMessages: number;
+  assistantMessages: number;
+  toolResults: number;
+  totalMessages: number;
+  tokens: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
+  cost: number;
+  contextUsage: JsonValue | null;
+}
+
+/** Raw facts from the box. It deliberately has no activity timestamps. */
+export interface SessionRuntimeFactDTO {
+  loaded: boolean;
+  isRunning: boolean;
+  isStreaming: boolean;
+  isRetrying: boolean;
+  isCompacting: boolean;
+  pendingMessageCount: number;
+  model: SessionModelDTO | null;
+}
+
+/** Raw box-local session facts. The host decorates these into WebState. */
+export interface SessionStateFactDTO {
+  cwd: string;
+  sessionFile: string;
+  sessionId: string;
+  sessionName: string | null;
+  sessionTitle: string;
+  isStreaming: boolean;
+  isRetrying: boolean;
+  isCompacting: boolean;
+  runtime: SessionRuntimeFactDTO;
+  model: SessionModelDTO | null;
+  thinkingLevel: string;
+  stats: SessionStatsFactDTO;
+  webFooters: JsonValue;
+  webHeaderActions: JsonValue;
+  webGitTabs: JsonValue;
+}
+
+/** Browser-only runtime projection. The host adds timestamps from pi events. */
+export interface WebSessionRuntimeDTO {
+  loaded: boolean;
+  isRunning: boolean;
+  isStreaming: boolean;
+  isRetrying: boolean;
+  isCompacting: boolean;
+  startedAt?: string;
+  lastActivityAt?: string;
+  pendingMessageCount: number;
+  model?: SimplifiedModelDTO;
+}
+
+/** Internal projection input may be sourced from the pi runtime. */
 export interface SessionStateProjectionInput {
   cwd: string;
   sessionFile: string;
@@ -99,6 +187,26 @@ export interface SessionStateProjectionInput {
   webGitTabs: unknown;
 }
 
-export interface SessionStateDTO extends Omit<SessionStateProjectionInput, "model"> {
-  model: SimplifiedModelDTO | undefined;
+/** Existing browser WebState projection; not the SessionService transport state. */
+export interface WebSessionStateDTO {
+  cwd: string;
+  sessionFile: string;
+  sessionId: string;
+  sessionName?: string;
+  sessionTitle: string;
+  isStreaming: boolean;
+  isRetrying: boolean;
+  isCompacting: boolean;
+  runtimeStartedAt?: string;
+  runtimeLastActivityAt?: string;
+  runtime: WebSessionRuntimeDTO;
+  model?: SimplifiedModelDTO;
+  thinkingLevel: string;
+  stats: SessionStatsDTO;
+  webFooters: JsonValue;
+  webHeaderActions: JsonValue;
+  webGitTabs: JsonValue;
 }
+
+/** Backwards-compatible name used by the current browser projection. */
+export type SessionStateDTO = WebSessionStateDTO;

--- a/server/session/projection.ts
+++ b/server/session/projection.ts
@@ -1,7 +1,9 @@
 import type {
   ConversationTreeDTO,
   ConversationTreeNodeDTO,
+  JsonValue,
   MessageEntryRefDTO,
+  WebSessionRuntimeDTO,
   SessionStateDTO,
   SessionStateProjectionInput,
   SessionStatsDTO,
@@ -34,12 +36,12 @@ export function simplifyModel(model: unknown): SimplifiedModelDTO | undefined {
   if (!model) return undefined;
   const value = model as UnknownRecord;
   return {
-    provider: value.provider,
-    id: value.id,
-    name: value.name || value.id,
+    provider: value.provider as string,
+    id: value.id as string,
+    name: (value.name || value.id) as string,
     reasoning: Boolean(value.reasoning),
-    contextWindow: value.contextWindow,
-    maxTokens: value.maxTokens,
+    contextWindow: value.contextWindow as number | undefined,
+    maxTokens: value.maxTokens as number | undefined,
   };
 }
 
@@ -431,7 +433,7 @@ export function projectSessionStats(entries: readonly unknown[], contextUsage: u
     totalMessages: entries.length,
     tokens: { input, output, cacheRead, cacheWrite, total: input + output + cacheRead + cacheWrite },
     cost,
-    contextUsage,
+    contextUsage: contextUsage as JsonValue | undefined,
   };
 }
 
@@ -447,7 +449,22 @@ export function projectSessionTitle(sessionName: string | undefined, messages: r
 
 export function projectSessionState(input: SessionStateProjectionInput): SessionStateDTO {
   return {
-    ...input,
+    cwd: input.cwd,
+    sessionFile: input.sessionFile,
+    sessionId: input.sessionId,
+    sessionName: input.sessionName,
+    sessionTitle: input.sessionTitle,
+    isStreaming: input.isStreaming as boolean,
+    isRetrying: input.isRetrying,
+    isCompacting: input.isCompacting,
+    runtimeStartedAt: input.runtimeStartedAt,
+    runtimeLastActivityAt: input.runtimeLastActivityAt,
+    runtime: input.runtime as WebSessionRuntimeDTO,
     model: simplifyModel(input.model),
+    thinkingLevel: input.thinkingLevel as string,
+    stats: input.stats,
+    webFooters: input.webFooters as JsonValue,
+    webHeaderActions: input.webHeaderActions as JsonValue,
+    webGitTabs: input.webGitTabs as JsonValue,
   };
 }

--- a/tests/session-api.contract.ts
+++ b/tests/session-api.contract.ts
@@ -1,0 +1,60 @@
+import type {
+  ArtifactBase64DTO,
+  DirectoryCreateRequest,
+  ExtensionGitTabRequest,
+  JsonObject,
+  PromptRequest,
+  SessionArtifactService,
+  SessionContext,
+  SessionFilesystemService,
+  SessionGitService,
+  SessionCreateRequest,
+  SessionMessageFactDTO,
+  SessionRuntimeFactDTO,
+  SessionService,
+  SessionServiceEvent,
+  SessionStateFactDTO,
+  TreeNavigationRequest,
+} from "../server/session/api.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends
+  (<Value>() => Value extends Right ? 1 : 2) ? true : false;
+type Assert<Value extends true> = Value;
+type OptionalKeys<Value extends object> = {
+  [Key in keyof Value]-?: {} extends Pick<Value, Key> ? Key : never;
+}[keyof Value];
+
+type SessionServiceMethods =
+  | "start" | "close" | "create" | "open" | "delete" | "list" | "switchCwd"
+  | "state" | "messages" | "stats" | "tree" | "commands" | "models"
+  | "prompt" | "abort" | "abortCompaction" | "retry" | "rename" | "setModel"
+  | "executeCommand" | "executeShell" | "navigateTree" | "abortBranchSummary"
+  | "respondExtensionUi" | "hasHeaderAction" | "invokeHeaderAction" | "hasGitTab" | "invokeGitTab"
+  | "acquireViewer" | "releaseViewer" | "fs" | "artifacts" | "git" | "subscribe";
+
+type _CompleteSurface = Assert<Equal<keyof SessionService, SessionServiceMethods>>;
+type _NoOptionalServiceMembers = Assert<Equal<OptionalKeys<SessionService>, never>>;
+type _NoOptionalFilesystemMembers = Assert<Equal<OptionalKeys<SessionFilesystemService>, never>>;
+type _NoOptionalArtifactMembers = Assert<Equal<OptionalKeys<SessionArtifactService>, never>>;
+type _NoOptionalGitMembers = Assert<Equal<OptionalKeys<SessionGitService>, never>>;
+type _ExplicitStateContext = Assert<Equal<Parameters<SessionService["state"]>, [context: SessionContext]>>;
+type _ExplicitPromptContext = Assert<Equal<Parameters<SessionService["prompt"]>, [context: SessionContext, request: PromptRequest]>>;
+type _ExplicitNavigationContext = Assert<Equal<Parameters<SessionService["navigateTree"]>, [context: SessionContext, request: TreeNavigationRequest]>>;
+type _BoxScopedDirectoryOperation = Assert<Equal<Parameters<SessionService["fs"]["mkdir"]>, [request: DirectoryCreateRequest]>>;
+type _ExplicitGitContext = Assert<Equal<Parameters<SessionService["git"]["status"]>[0], SessionContext>>;
+type _StartUsesServiceOwnedIdentity = Assert<Equal<Parameters<SessionService["start"]>, []>>;
+type _CloseUsesServiceOwnedIdentity = Assert<Equal<Parameters<SessionService["close"]>, []>>;
+type _CreateHasNoRemoteSessionFile = Assert<Equal<Extract<keyof SessionCreateRequest, "previousSessionFile">, never>>;
+type _RawStateHasNoActivityTimestamps = Assert<Equal<Extract<keyof SessionStateFactDTO, "runtimeStartedAt" | "runtimeLastActivityAt">, never>>;
+type _RawRuntimeHasNoActivityTimestamps = Assert<Equal<Extract<keyof SessionRuntimeFactDTO, "startedAt" | "lastActivityAt">, never>>;
+type _RawMessageHasNoActivityTimestamp = Assert<Equal<Extract<keyof SessionMessageFactDTO, "startedAt" | "lastActivityAt">, never>>;
+// @ts-expect-error JSON object values cannot be undefined.
+const invalidJsonObject: JsonObject = { missing: undefined };
+void invalidJsonObject;
+type _GitTabPayloadIsTransportSafe = Assert<Equal<Parameters<SessionService["invokeGitTab"]>[1], ExtensionGitTabRequest>>;
+type _ArtifactReadContext = Assert<Equal<Parameters<SessionService["artifacts"]["readBase64"]>[0], SessionContext>>;
+type _ArtifactHasNoFilesystemPath = Assert<Equal<Extract<keyof ArtifactBase64DTO, "file" | "path">, never>>;
+type _EventsAreDiscriminated = Assert<Equal<Extract<SessionServiceEvent, { type: "models_updated" }>["type"], "models_updated">>;
+
+export {};

--- a/tests/session-api.test.ts
+++ b/tests/session-api.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  serializeSessionTransport,
+  type ArtifactBase64DTO,
+  type JsonValue,
+  type ServiceResult,
+  type SessionServiceEvent,
+  type SessionStateFactDTO,
+} from "../server/session/api.js";
+
+function jsonRoundTrip<T extends JsonValue>(value: T): T {
+  return serializeSessionTransport(value);
+}
+
+describe("SessionService transport contract", () => {
+  it("round-trips representative method results without host filesystem paths", () => {
+    const artifact: ArtifactBase64DTO = {
+      name: "report.png",
+      mimeType: "image/png",
+      base64: "cG5n",
+    };
+    const result: ServiceResult<ArtifactBase64DTO> = { ok: true, value: artifact };
+
+    expect(jsonRoundTrip(result as unknown as JsonValue)).toEqual({ ok: true, value: artifact });
+    expect("file" in artifact).toBe(false);
+    expect("path" in artifact).toBe(false);
+  });
+
+  it("round-trips raw box facts without browser activity decoration", () => {
+    const state: SessionStateFactDTO = {
+      cwd: "/workspace",
+      sessionFile: "/workspace/.pi/sessions/session.jsonl",
+      sessionId: "session-1",
+      sessionName: null,
+      sessionTitle: "Session",
+      isStreaming: true,
+      isRetrying: false,
+      isCompacting: false,
+      runtime: {
+        loaded: true,
+        isRunning: true,
+        isStreaming: true,
+        isRetrying: false,
+        isCompacting: false,
+        pendingMessageCount: 0,
+        model: null,
+      },
+      model: null,
+      thinkingLevel: "medium",
+      stats: {
+        userMessages: 1,
+        assistantMessages: 0,
+        toolResults: 0,
+        totalMessages: 1,
+        tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        cost: 0,
+        contextUsage: null,
+      },
+      webFooters: [],
+      webHeaderActions: [],
+      webGitTabs: [],
+    };
+    const event: SessionServiceEvent = {
+      type: "models_updated",
+      sessionId: "session-1",
+      models: [{
+        provider: "example",
+        id: "model-1",
+        name: "Model 1",
+        reasoning: true,
+        contextWindow: 128000,
+        maxTokens: 8192,
+        metadata: { vendorMetadata: { tier: "preview" } },
+      }],
+    };
+
+    expect(jsonRoundTrip({ state, event })).toEqual({ state, event });
+    expect("runtimeStartedAt" in state).toBe(false);
+    expect("runtimeLastActivityAt" in state).toBe(false);
+    expect("startedAt" in state.runtime).toBe(false);
+    expect("lastActivityAt" in state.runtime).toBe(false);
+  });
+
+  it("rejects explicit undefined instead of silently dropping it during JSON serialization", () => {
+    expect(() => serializeSessionTransport({ value: undefined } as unknown as JsonValue)).toThrow("undefined");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "resolveJsonModule": true,
     "noEmit": true
   },
-  "include": ["server.ts", "supervisor.ts", "vite.config.ts", "src/**/*.ts", ".pi/extensions/**/*.ts"]
+  "include": ["server.ts", "supervisor.ts", "vite.config.ts", "src/**/*.ts", ".pi/extensions/**/*.ts", "tests/session-api.contract.ts"]
 }


### PR DESCRIPTION
## Stage 2e protocol foundation

Defines the complete box-local `SessionService` contract before moving production behavior:

- explicit session context for every session operation; no global-current default
- non-optional lifecycle/session/model/command/tree/extension/viewer surface
- box-scoped filesystem API usable before session creation
- full session-scoped Git and artifact APIs
- artifact bytes cross the boundary, never box-local file paths
- raw state/runtime/message facts contain no host-derived activity timestamps
- host-only WebState DTO remains separate
- typed discriminated service events, shutdown, and extension UI requests
- strict JSON transport validation that rejects undefined/non-finite/function values

No routes or session lifecycle code move in this slice.

Validation: compile-time completeness assertions, JSON round-trip tests, typecheck, full unit/E2E suite, build, diff check.
