### PR TITLE
Make SessionService self-contained

### DIFF
--- a/docs/runtime-binding-design.md
+++ b/docs/runtime-binding-design.md
@@ -1,21 +1,97 @@
 # Per-session runtime binding design
 
-Issue context: GitHub issue #3 proposes that pi-web should support both normal host sessions and sandboxed sessions at the same time. The runtime choice is made per session, not globally.
+GitHub issue #3 proposes running normal host sessions and sandboxed sessions at the same time. Runtime selection is per session; changing where one session runs must not create a reduced pi-web feature set.
 
-## Goals
+## Product invariants
 
-- Keep current host behavior unchanged by default.
-- Let a user choose a trust boundary when creating/opening a session.
-- Support managed sandboxes created by pi-web and external sandboxes created by the user.
-- Do not require one worktree per session. Multiple sessions may attach to the same runtime/cwd, with warnings only.
-- Make existing API routes runtime-aware without duplicating UI behavior.
+- Local behavior remains the default and must not change.
+- A session is authoritative on the box where it runs. The host keeps connection configuration and routing metadata, not a second transcript.
+- Runtime choice changes the trust boundary, not the session feature surface.
+- Missing, stale, or conflicting bindings fail closed. They never fall back to the host.
+- Session IDs remain the user-facing identity. Runtime information is a routing attribute.
+- Managed runtimes and user-managed runtimes may have different lifecycle and network policies, but they use the same session API.
 
-## Non-goals for the first implementation
+## Staged architecture
 
-- Perfect concurrent edit isolation.
-- A full container orchestration product.
-- Replacing the current local `createAgentSession` path.
-- Rewriting all pi-web session history storage in one change.
+```text
+Browser
+  -> HTTP/WebSocket serving layer
+  -> binding-authoritative SessionRouter                 (Stage 4)
+       -> local SessionService in process
+       -> RemoteSessionService -> stdio runner
+                                  -> same SessionService  (Stage 3)
+  -> runtime providers, model broker, management UI      (Stage 5)
+```
+
+### Stage 2 and 2.5: one self-contained local service
+
+`server/session/service.ts` owns all box-local session behavior:
+
+- live-session cache and lookup;
+- viewer/work leases, idle cleanup, shutdown, and disposal;
+- session creation, opening, deletion, listing, and cwd switching;
+- prompts and image persistence, retries, tree navigation, slash/shell commands, models, and projections;
+- extension loading and extension web-UI bindings.
+
+The service can be constructed without `server.ts`. Its dependency interface contains only six box externals: the canonical model/auth runtime, an optional session factory (used by the mock harness), extension paths, session configuration, global cwd, and browser client count. Session configuration groups settings defaults with one host post-create finalizer; every creation path awaits that finalizer before it can publish state, so host-owned default bucket state remains ordered ahead of `state_changed` even for extension-created sessions.
+
+`server.ts` remains the serving layer. It owns the current-session route default, browser viewer sockets, activity/tool-timing decoration, realtime sequencing, unread state, session UI state, and current-tab UI-state transfer. State returned by the service is `BaseSessionStateDto`; the serving layer adds host-only fields as a typed intersection before sending it.
+
+### Event boundary
+
+`SessionService.subscribe()` emits serializable `SessionServiceEvent` values. Pi events are emitted with `sessionId` and `sessionFile`; state, stats, blocked-model updates, errors, and shutdown are explicit typed variants. The local implementation intentionally JSON-round-trips each event before delivery. This normalizes unsupported non-JSON values at the future runner boundary rather than exposing in-process-only behavior. Listener failures are also intentionally isolated and logged so one serving adapter cannot interrupt wire-order delivery to other subscribers. On the supported JSON event domain, values are unchanged and safe to pass through `JSON.stringify`/`JSON.parse`.
+
+The local server subscribes once. For each Pi event it performs host activity enrichment and preserves this exact browser wire order:
+
+```text
+pi_event
+session_runtime_changed
+[state_changed]
+[session_stats_changed]
+[models_updated]
+```
+
+The bracketed messages are emitted only for the same source events as before. Extension web-UI events use the same service event sink and retain their existing browser wire shapes. Browser activity, realtime replay/sequence numbers, unread tracking, and UI stores are deliberately not part of the runner protocol.
+
+`NavigationResult.finish()` is the one intentional non-serializable value. It is a serving-side finalizer: the serving adapter writes the navigation response and calls `finish()` in `finally`. A future remote runner must likewise finalize after writing its own response; the callback is never sent over stdio.
+
+### Stage 3: runner transport
+
+The runner is a thin transport over the same `LocalSessionService`, not another implementation:
+
+- newline-delimited request/response dispatch;
+- forwarding `SessionServiceEvent` values;
+- a health handshake containing protocol version and build hash;
+- fail-closed rejection of incompatible builds.
+
+A typed `SessionApi` is derived from the service interface. The service contract suite runs both in process and over a spawned runner, creating a permanent parity ratchet. The runner contains no projections, lifecycle policy, capability matrix, or feature-specific session logic.
+
+### Stage 4: binding-authoritative routing
+
+A `RuntimeRegistry` owns the local service and dynamic runtime providers. A `SessionRouter` resolves persisted bindings before every session-scoped operation:
+
+1. A stored local binding routes to the in-process service.
+2. A stored remote binding routes to that runtime's `RemoteSessionService`.
+3. An explicit runtime that conflicts with the binding returns a conflict.
+4. A missing/unavailable provider returns an unavailable response.
+5. No case silently executes against the host.
+
+Creation binds transactionally. Delete/release, WebSocket hello, reconnect, and provider replacement all pass through the same router and lifecycle rules.
+
+A first binding store may live at `.pi/web/runtime-bindings.json`; it is server-owned metadata rather than part of the core pi session format.
+
+### Stage 5: providers, broker, and UI
+
+After parity and routing are enforced, add runtime providers and product UI:
+
+- stdio clients and command/container/SSH providers;
+- managed-runtime network isolation;
+- a host-side model broker for approved model operations without copying host credentials into managed runtimes;
+- runtime connection and health management;
+- an explicit per-browser-tab workbench runtime selector;
+- runtime-scoped folder browsing and session creation.
+
+Provider implementations vary only transport and lifecycle. Frontend capability gates are not used to excuse service drift.
 
 ## Runtime model
 
@@ -35,225 +111,24 @@ export type SandboxRuntime = {
 };
 ```
 
-Persist a binding:
+Bindings map `sessionId -> RuntimeRef`. Cwd history is runtime-relative. The drawer may render cached locator rows immediately and reconcile in the background, but a successful authoritative runtime listing is required before removing stale rows.
 
-```text
-sessionId -> RuntimeRef
-```
+## UX and lifecycle rules
 
-The binding should live in server-owned web metadata, not in the core pi session file format initially. A simple first store can be `.pi/web/runtime-bindings.json` keyed by session id.
+- The active workbench runtime is per browser tab, never server-global.
+- Opening a session shows its runtime context; changing the new-session default is explicit.
+- “Remove from list” removes host locator metadata and works offline.
+- “Delete session” requires the authoritative runtime and deletes the underlying session there.
+- Runtime disconnection shows reconnect/recovery UI and never triggers local fallback.
+- Managed ephemeral containers need durable mounted session storage or must be labeled disposable.
+- Brief transport loss reconnects and resubscribes; confirmed runner death clears running/activity state.
 
-## Server architecture
+## Validation strategy
 
-Introduce a small adapter layer around host and sandbox execution.
-
-```ts
-interface RuntimeAdapter {
-  ref: RuntimeRef;
-  getState(sessionId: string): Promise<PiWebState>;
-  getMessages(sessionId: string): Promise<SimplifiedMessage[]>;
-  prompt(input: PromptRequest): Promise<{ sessionId: string }>;
-  abort(sessionId: string): Promise<void>;
-  listGitRepos(sessionId: string): Promise<GitRepo[]>;
-  gitStatus(request: GitStatusRequest): Promise<GitStatusResponse>;
-  gitDiff(request: GitDiffRequest): Promise<GitDiffResponse>;
-  gitSync(request: GitSyncRequest): Promise<GitSyncResponse>;
-  listDirs(path: string): Promise<DirectoryListing>;
-  createDir(parent: string, name: string): Promise<DirectoryListing>;
-  artifact(name: string): Promise<ArtifactResult>;
-}
-```
-
-### Host adapter
-
-The host adapter wraps existing server functions:
-
-- `makeAgentSession`
-- `getOrCreateLiveSessionById`
-- `createNewLiveSession`
-- `liveSessions`
-- `sessionCwd`
-- local git/fs/artifact helpers
-
-This should be mostly extraction/refactoring. Behavior should remain byte-for-byte compatible where possible.
-
-### Sandbox adapter
-
-The sandbox adapter proxies to a worker running inside a Docker container, VM, or user-managed environment.
-
-Expected worker surface:
-
-```text
-GET  /health
-POST /sessions/new
-POST /sessions/:id/prompt
-POST /sessions/:id/abort
-GET  /sessions/:id/state
-GET  /sessions/:id/messages
-GET  /git/repos?sessionId=...
-GET  /git/status?sessionId=...&repo=...
-GET  /git/diff?sessionId=...&repo=...&path=...
-POST /git/sync
-GET  /fs/dirs?path=...
-POST /fs/dirs
-GET  /artifacts/:name
-WS   /events
-```
-
-The worker should emit the same logical event types pi-web already broadcasts, so the UI can stay mostly unchanged.
-
-## Request routing
-
-Add a resolver:
-
-```ts
-async function runtimeForSessionId(sessionId?: string): Promise<RuntimeAdapter>;
-```
-
-Rules:
-
-1. If no `sessionId`, use the current active session binding.
-2. If the session has no binding, default to `{ kind: "host", cwd: sessionCwd(...) }` and persist it lazily.
-3. For new sessions, use the runtime selected in the request body.
-4. For opening historical sessions, use existing binding; if missing, assume host.
-
-Routes to move behind adapters first:
-
-- `/api/prompt`
-- `/api/abort`
-- `/api/state`
-- `/api/messages`
-- `/api/sessions/new`
-- `/api/sessions/open`
-- `/api/git/repos`
-- `/api/git/status`
-- `/api/git/diff`
-- `/api/git/sync`
-- `/api/artifacts/*`
-- `/api/fs/dirs`
-- `/api/session/cwd`
-
-## API additions
-
-```text
-GET  /api/runtimes
-POST /api/runtimes/managed
-POST /api/runtimes/external
-GET  /api/sessions/:id/runtime
-PATCH /api/sessions/:id/runtime
-```
-
-Example new-session body:
-
-```json
-{
-  "cwd": "/workspace/pi-web",
-  "runtime": { "kind": "sandbox", "sandboxId": "sensitive-work", "cwd": "/workspace/pi-web" }
-}
-```
-
-## UX design
-
-### New session flow
-
-```text
-Start session in:
-  ○ Host machine
-  ○ Existing sandbox
-      sensitive-work · sandbox · network off
-      private-client · sandbox · network on
-      disposable · sandbox
-  ○ Create sandbox...
-  ○ Connect external sandbox...
-```
-
-### Session drawer metadata
-
-```text
-Fix reload issue
-pi-web · host
-
-Review sensitive client repo
-sensitive-work · sandbox · network off
-```
-
-### Warnings
-
-Show non-blocking warnings when:
-
-- Multiple live sessions attach to the same sandbox and cwd.
-- Sandbox health is unknown or disconnected.
-- The selected cwd is outside the sandbox-mounted workspace.
-- A sandbox has network enabled for a session marked sensitive.
-
-## Managed sandbox MVP
-
-Docker is the simplest first managed runtime.
-
-Suggested shape:
-
-```text
-pi-web server
-  creates container
-  mounts selected host repo to /workspace/<name>
-  starts pi-web sandbox worker inside container
-  stores sandbox metadata
-  proxies session operations to worker
-```
-
-Initial policy knobs:
-
-- mount path
-- read/write vs read-only mount
-- network on/off
-- environment/secrets allowlist
-- image name/tag
-
-## External sandbox MVP
-
-For user-created sandboxes, pi-web only stores:
-
-- name
-- endpoint URL
-- optional auth token
-- display metadata: network/cwd/description
-
-Health check verifies `/health` and protocol version.
-
-## Event forwarding
-
-Each sandbox adapter maintains a worker WebSocket connection. Incoming sandbox events are normalized and rebroadcast through the existing pi-web WebSocket stream:
-
-```text
-sandbox worker event -> sandbox adapter -> pi-web broadcast(...) -> browser
-```
-
-Events must include `sessionId` and runtime metadata so the browser can reconcile active sessions.
-
-## Rollout plan
-
-1. Add `RuntimeRef` types and runtime binding store.
-2. Persist host bindings for current and newly created sessions.
-3. Extract current host behavior into `HostRuntimeAdapter` with no UX changes.
-4. Route `/api/prompt`, `/api/state`, `/api/messages`, and `/api/abort` through the adapter resolver.
-5. Add `/api/runtimes` and UI display of runtime badges.
-6. Add external sandbox adapter and worker protocol.
-7. Add runtime selection to new-session/open-session flow.
-8. Add Docker managed sandbox creation.
-9. Move git/fs/artifact routes fully behind adapters.
-10. Add tests for host compatibility and sandbox proxy behavior.
-
-## Test strategy
-
-- Unit test binding store migration/defaulting.
-- API tests proving current host behavior is unchanged.
-- Mock sandbox worker tests for prompt/state/messages/abort.
-- Git/fs/artifact route tests for both host and sandbox adapters.
-- E2E tests for new-session runtime selection and session drawer badges.
-
-## Open questions
-
-- Should artifacts remain globally addressable by filename, or include session/runtime in the URL for sandbox artifacts?
-- How should sandbox worker authentication be configured for external sandboxes?
-- Should managed sandbox lifecycle follow session lifecycle, or be explicitly user-controlled?
-- How much of model/auth configuration should be copied into managed sandboxes vs proxied from host?
+- The in-process standalone service test covers create -> prompt -> state/messages/events without importing `server.ts`.
+- Every service result and emitted event must be JSON-round-trip stable.
+- Source guards keep Pi session member access out of route bodies and retain response-before-navigation-finalizer ordering.
+- Stage 3 runs the same contract suite over stdio.
+- Stage 4 tests absent runtime IDs, explicit conflicts, stale providers, cloned IDs, WebSocket hello, release, and transactional create.
+- Provider tests cover reconnect, isolation, broker validation, and authoritative reconciliation.
+- Full browser tests continue to verify unchanged local behavior and extension web UI.

--- a/server.ts
+++ b/server.ts
@@ -1,23 +1,13 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { createReadStream, existsSync, readFileSync } from "node:fs";
-import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { dirname, extname, join, resolve } from "node:path";
+import { createReadStream, existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { extname, join, resolve } from "node:path";
 import { createServer as createViteServer, type ViteDevServer } from "vite";
 import { fileURLToPath } from "node:url";
 import { WebSocketServer, type WebSocket } from "ws";
-import {
-  createAgentSession,
-  getAgentDir,
-  ModelRuntime,
-  SessionManager,
-  type SessionStartEvent,
-} from "@earendil-works/pi-coding-agent";
+import { getAgentDir, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { createMockHarness } from "./server/mock.js";
 import { resolveBundledExtensionPaths, resolvePiWebExtensionPaths } from "./server/extensions.js";
-import { ResilientResourceLoader } from "./server/extensions/resilientLoader.js";
 import { createSessionUiStateStore, defaultSessionUiState } from "./server/sessionUiState.js";
 import { createSettingsStore } from "./server/settings.js";
 import { findArtifactFile, isValidArtifactPath } from "./server/shared/artifacts.js";
@@ -25,25 +15,12 @@ import { assertDirectory, createDirectory, listDirectories } from "./server/shar
 import { gitCommitDetails, gitCwdFromRepoParam, gitDiff, gitLog, gitStatus, gitSync, isGitRepo, listGitRepos, readGitImage } from "./server/shared/git.js";
 import { listWorkspaceDirectory, readWorkspaceFile, readWorkspaceImage, WorkspaceFileError, writeWorkspaceFile } from "./server/shared/workspaceFiles.js";
 import type { PiWebSession } from "./server/types.js";
-import type { SlashCommandDto } from "./server/session/dto.js";
+import type { BaseSessionStateDto, SessionInfoDto } from "./server/session/dto.js";
 import { SessionActivity } from "./server/session/activity.js";
+import { createHostSessionEventHandler, decorateHostMessages, decorateHostSessionState, resolveWebSocketHelloSession, type DecoratedSessionState, type WireSessionState } from "./server/session/hostEvents.js";
 import { RealtimeHub, SessionUnreadTracker } from "./server/realtime.js";
-import { createWebUiBridge } from "./server/extensions/webUi.js";
 import { LocalSessionService, SessionServiceError } from "./server/session/service.js";
-import {
-  conversationTreeForSession,
-  getSessionSlashCommands,
-  isAssistantAbortedMessage,
-  isAssistantFailureMessage,
-  isIncompleteToolResultMessage,
-  messageEntryRefs,
-  projectSessionState,
-  sessionIsRetrying,
-  sessionStats,
-  simplifyMessage,
-  simplifyModel,
-  textFromContent,
-} from "./server/session/projection.js";
+
 
 const appDir = resolve(fileURLToPath(new URL(".", import.meta.url)));
 const distDir = join(appDir, "dist");
@@ -56,28 +33,8 @@ const token = process.env.PI_WEB_TOKEN || "";
 let piCwd = resolve(process.env.PI_WEB_CWD || process.cwd());
 const knownCwds = new Set<string>([piCwd]);
 
-const webUiContextFile = join(appDir, "contexts", "web-ui.md");
 const bundledExtensionsDir = join(appDir, ".pi", "extensions");
-const noSession = process.env.PI_WEB_NO_SESSION === "1";
 const mockMode = process.env.PI_WEB_MOCK === "1";
-const execFileAsync = promisify(execFile);
-
-type WebSlashCommandInfo = SlashCommandDto;
-
-const webSlashCommands: WebSlashCommandInfo[] = [
-  { name: "help", description: "Show slash command help", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-  { name: "commands", description: "List available web, extension, prompt, and skill commands", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-  { name: "reload", description: "Reload pi resources, extensions, skills, prompts, and models", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-  { name: "model", description: "List models or switch with /model <provider/model-id>", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-  { name: "models", description: "List available models", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-  { name: "thinking", description: "Show or set reasoning level", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-  { name: "new", description: "Start a new session", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-  { name: "clear", description: "Release this session to history and start fresh in the same tab", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-  { name: "compact", description: "Compact conversation context; optional instructions after the command", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-  { name: "abort", description: "Stop the current response", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-  { name: "stop", description: "Stop the current response", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-  { name: "logout", description: "Clear the web UI token in this browser", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
-];
 
 const contentTypes: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -136,7 +93,7 @@ function serveArtifact(req: IncomingMessage, res: ServerResponse) {
   const artifactPath = decodeURIComponent(url.pathname.slice("/api/artifacts/".length));
   if (!isValidArtifactPath(artifactPath)) return sendJson(res, 400, { ok: false, error: "Invalid artifact path" });
 
-  const artifactRoots = new Set([piCwd, ...knownCwds]);
+  const artifactRoots = new Set([piCwd, ...knownCwds, ...sessionService.knownCwds()]);
   const resolvedFile = findArtifactFile(artifactRoots, artifactPath);
   if (!resolvedFile) return sendJson(res, 404, { ok: false, error: "Artifact not found" });
 
@@ -162,10 +119,6 @@ function serveStatic(req: IncomingMessage, res: ServerResponse) {
   pipeReadStream(res, file);
 }
 
-function hasUserMessages(value: PiWebSession) {
-  return value.messages.some((message: any) => message?.role === "user");
-}
-
 async function ensurePiWebStorage(cwd = piCwd) {
   const webDir = join(cwd, ".pi", "web");
   await mkdir(webDir, { recursive: true });
@@ -181,192 +134,15 @@ async function setPiCwd(path: string) {
 
 async function requestCwdFromSessionId(sessionId: string | null) {
   if (!sessionId) return piCwd;
-  if (sessionId === session.sessionId) return sessionCwd(session);
-  for (const entry of liveSessions.values()) {
-    if (entry.session.sessionId === sessionId) return sessionCwd(entry.session);
-  }
-  const info = await findSessionInfoById(sessionId);
-  if (!info) throw new Error("Session not found");
-  return info.cwd || piCwd;
-}
-
-// Models confirmed broken with this Copilot integration — tracked at runtime.
-const blockedModelIds = new Set<string>();
-
-// Parse allowed model IDs from Copilot's model_not_available_for_integrator error.
-// Returns null if no such error has been seen yet.
-function copilotAllowedIdsFromSession(targetSession: PiWebSession = session): Set<string> | null {
-  const entries = targetSession.messages;
-  for (let i = entries.length - 1; i >= 0; i--) {
-    const msg = entries[i] as any;
-    const err: string = msg?.errorMessage || msg?.message?.errorMessage || "";
-    if (!err.includes("model_not_available_for_integrator")) continue;
-    const match = err.match(/Available models: \[([^\]]+)\]/);
-    if (!match) continue;
-    return new Set(match[1].split(/\s+/).map((s: string) => s.trim()).filter(Boolean));
-  }
-  return null;
-}
-
-function getAvailableModels(targetSession: PiWebSession = session) {
-  const all = targetSession.modelRuntime.getAvailableSnapshot();
-  const allowed = copilotAllowedIdsFromSession(targetSession);
-  return all.filter((m: any) => {
-    if (blockedModelIds.has(m.id)) return false;
-    if (allowed && !allowed.has(m.id)) return false;
-    return true;
-  });
-}
-
-const imageExtensions: Record<string, string> = {
-  "image/gif": ".gif",
-  "image/jpeg": ".jpg",
-  "image/png": ".png",
-  "image/webp": ".webp",
-};
-
-async function persistPromptImages(images: Array<{ data: string; mimeType: string; name?: string }>, cwd = piCwd) {
-  if (!images.length) return "";
-  await ensurePiWebStorage(cwd);
-  const uploadDir = join(cwd, ".pi", "web", "uploads");
-  await mkdir(uploadDir, { recursive: true });
-
-  const lines: string[] = [];
-  for (const image of images) {
-    const extension = imageExtensions[image.mimeType] || ".img";
-    const safeName = String(image.name || "image").replace(/[^a-zA-Z0-9._-]+/g, "_").slice(0, 80);
-    const fileName = `${new Date().toISOString().replace(/[:.]/g, "-")}-${randomUUID()}-${safeName}${safeName.endsWith(extension) ? "" : extension}`;
-    const filePath = join(uploadDir, fileName);
-    const data = Buffer.from(image.data, "base64");
-    await writeFile(filePath, data);
-    lines.push(`- ${filePath}`);
-  }
-
-  return `\n\nAttached image file${images.length === 1 ? "" : "s"}:\n${lines.join("\n")}`;
+  return sessionService.cwdForSessionId(sessionId);
 }
 
 function sessionCwd(targetSession: PiWebSession | any = session) {
-  return String(targetSession?.sessionManager?.getCwd?.() || targetSession?.cwd || piCwd);
+  return sessionService ? sessionService.cwdForSession(targetSession) : String(targetSession?.sessionManager?.getCwd?.() || targetSession?.cwd || piCwd);
 }
 
-type RetrySessionTarget =
-  | { kind: "failure"; messages: any[]; index: number; message: any }
-  | { kind: "aborted"; messages: any[]; index: number; message: any }
-  | { kind: "toolResult"; messages: any[]; index: number; message: any };
-
-function trailingRetryTarget(targetSession: PiWebSession): RetrySessionTarget | undefined {
-  const messages = Array.isArray(targetSession.agent?.state?.messages) ? targetSession.agent.state.messages as any[] : [];
-  const index = messages.length - 1;
-  const message = index >= 0 ? messages[index] : undefined;
-  if (isAssistantFailureMessage(message)) return { kind: "failure", messages, index, message };
-  if (isAssistantAbortedMessage(message)) return { kind: "aborted", messages, index, message };
-  if (isIncompleteToolResultMessage(message)) return { kind: "toolResult", messages, index, message };
-  return undefined;
-}
-
-function branchBeforeTrailingMessages(targetSession: PiWebSession, shouldBranchBefore: (message: any) => boolean) {
-  const manager = targetSession.sessionManager;
-  if (typeof manager.getBranch !== "function") return false;
-  let branch: any[];
-  try {
-    branch = manager.getBranch();
-  } catch {
-    return false;
-  }
-  if (!Array.isArray(branch)) return false;
-
-  let lastMessageIndex = -1;
-  for (let index = branch.length - 1; index >= 0; index -= 1) {
-    if (branch[index]?.type === "message") {
-      lastMessageIndex = index;
-      break;
-    }
-  }
-  if (lastMessageIndex < 0) return false;
-  const lastMessage = branch[lastMessageIndex]?.message;
-  if (!shouldBranchBefore(lastMessage)) return false;
-
-  let firstRemovedIndex = lastMessageIndex;
-  while (firstRemovedIndex > 0) {
-    const previous = branch[firstRemovedIndex - 1];
-    if (previous?.type !== "message" || !shouldBranchBefore(previous.message)) break;
-    firstRemovedIndex -= 1;
-  }
-
-  const firstRemoved = branch[firstRemovedIndex];
-  const parentId = typeof firstRemoved?.parentId === "string" ? firstRemoved.parentId : null;
-  if (parentId && typeof manager.branch === "function") manager.branch(parentId);
-  else if (!parentId && typeof manager.resetLeaf === "function") manager.resetLeaf();
-  else return false;
-  return true;
-}
-
-function syncAgentMessagesToSessionContext(targetSession: PiWebSession) {
-  const internal = targetSession as any;
-  if (typeof targetSession.sessionManager?.buildSessionContext !== "function") return false;
-  internal.agent.state.messages = targetSession.sessionManager.buildSessionContext().messages;
-  return true;
-}
-
-function assertCanRetryFromFailure(targetSession: PiWebSession) {
-  if (targetSession.isStreaming) throw new Error("Wait for the current response to finish before retrying.");
-  if (targetSession.isCompacting) throw new Error("Wait for compaction to finish before retrying.");
-  if (!trailingRetryTarget(targetSession)) throw new Error("There is no failed or incomplete response to retry.");
-}
-
-async function retrySessionFromFailure(targetSession: PiWebSession) {
-  assertCanRetryFromFailure(targetSession);
-  if (typeof targetSession.retryFromFailure === "function") {
-    await targetSession.retryFromFailure();
-    return;
-  }
-
-  const target = trailingRetryTarget(targetSession);
-  if (!target) throw new Error("There is no failed or incomplete response to retry.");
-
-  const internal = targetSession as any;
-  if (!internal.agent || typeof internal.agent.continue !== "function") throw new Error("Continuing is not available in this session.");
-
-  if (target.kind === "failure") {
-    const branched = branchBeforeTrailingMessages(targetSession, isAssistantFailureMessage);
-    if (!branched || !syncAgentMessagesToSessionContext(targetSession)) {
-      while (target.messages.length > 0 && isAssistantFailureMessage(target.messages[target.messages.length - 1])) target.messages.pop();
-    }
-  } else if (target.kind === "aborted") {
-    const branched = branchBeforeTrailingMessages(targetSession, isAssistantAbortedMessage);
-    if (!branched || !syncAgentMessagesToSessionContext(targetSession)) {
-      if (isAssistantAbortedMessage(target.messages[target.messages.length - 1])) target.messages.pop();
-    }
-  }
-
-  try {
-    await internal.agent.continue();
-    while (typeof internal._handlePostAgentRun === "function" && await internal._handlePostAgentRun()) {
-      await internal.agent.continue();
-    }
-  } finally {
-    internal._systemPromptOverride = undefined;
-    if (typeof internal._flushPendingBashMessages === "function") internal._flushPendingBashMessages();
-  }
-}
-
-function rememberSessionLocation(info: { id: string; path: string; cwd?: string }, cwd = piCwd) {
-  if (info.id && info.path) sessionLocations.set(info.id, { path: resolve(info.path), cwd: resolve(info.cwd || cwd) });
-}
-
-function simplifySessionInfo(info: Awaited<ReturnType<typeof SessionManager.list>>[number], cwd = piCwd) {
-  rememberSessionLocation(info, cwd);
-  return {
-    id: info.id,
-    name: info.name,
-    firstMessage: info.firstMessage,
-    created: info.created.toISOString(),
-    modified: info.modified.toISOString(),
-    messageCount: info.messageCount,
-    cwd: info.cwd || cwd,
-    isCurrent: false,
-    runtime: sessionActivity.runtimeForPath(info.path),
-  };
+function resolveSessionId(value: unknown) {
+  return typeof value === "string" && value.length > 0 ? value : session.sessionId;
 }
 
 function applySessionUnreadState<T extends { id: string }>(sessions: T[], sessionUiState: { sessionUnreadStates?: Array<{ sessionId: string; unreadAt: string }> }) {
@@ -377,431 +153,66 @@ function applySessionUnreadState<T extends { id: string }>(sessions: T[], sessio
   });
 }
 
-const sessionListRequests = new Map<string, Promise<ReturnType<typeof simplifySessionInfo>[]>>();
-
-async function listSessionInfos(extraCwds: string[] = []) {
-  if (noSession) return [];
-  if (mockMode) return mockSessions.map((info) => simplifySessionInfo(info as any, info.cwd || piCwd));
-  const cwds = new Set<string>(knownCwds);
-  for (const cwd of extraCwds) {
-    if (typeof cwd !== "string" || !cwd.trim()) continue;
-    cwds.add(resolve(cwd));
-  }
-  const orderedCwds = Array.from(cwds).sort();
-  const key = orderedCwds.join("\n");
-  const existing = sessionListRequests.get(key);
-  if (existing) return existing;
-  const request = (async () => {
-    const groups = await Promise.all(orderedCwds.map(async (cwd) => {
-      try {
-        const sessions = await SessionManager.list(cwd);
-        return sessions.map((info) => simplifySessionInfo(info, cwd));
-      } catch {
-        return [];
-      }
-    }));
-    return groups.flat().sort((a, b) => Date.parse(b.modified) - Date.parse(a.modified));
-  })();
-  sessionListRequests.set(key, request);
-  try { return await request; }
-  finally { sessionListRequests.delete(key); }
+function decorateState(baseState: BaseSessionStateDto, targetSession: PiWebSession, includeThinkingLevels = false): WireSessionState {
+  return decorateHostSessionState(baseState, targetSession, sessionActivity, (value) => sessionService.webUiEntries(value), includeThinkingLevels);
 }
 
 function currentState(targetSession: PiWebSession = session) {
-  const projected = projectSessionState(targetSession, sessionCwd(targetSession));
-  const { thinkingLevels: _thinkingLevels, ...base } = projected;
-  const isRunning = Boolean(projected.isStreaming || projected.isRetrying || projected.isCompacting);
-  return {
-    ...base,
-    runtimeStartedAt: typeof (targetSession as any).runtimeStartedAt === "string"
-      ? (targetSession as any).runtimeStartedAt
-      : sessionActivity.startedAtForPath(targetSession.sessionFile, isRunning),
-    runtimeLastActivityAt: typeof (targetSession as any).runtimeLastActivityAt === "string"
-      ? (targetSession as any).runtimeLastActivityAt
-      : sessionActivity.lastActivityAtForPath(targetSession.sessionFile, isRunning),
-    runtime: sessionActivity.runtimeForPath(targetSession.sessionFile),
-    ...webUiBridge.entries(targetSession),
-  };
+  return decorateState(sessionService.projectState(targetSession), targetSession);
 }
 
 function currentStateWithThinkingLevels(targetSession: PiWebSession = session) {
-  return {
-    ...currentState(targetSession),
-    thinkingLevels: targetSession.getAvailableThinkingLevels(),
-  };
+  return decorateState(sessionService.projectState(targetSession), targetSession, true);
 }
 
-function getSlashCommands(value: any = session): WebSlashCommandInfo[] {
-  return [...webSlashCommands, ...getSessionSlashCommands(value)];
+async function decorateServiceState(baseState: BaseSessionStateDto, includeThinkingLevels = true): Promise<DecoratedSessionState> {
+  return decorateState(baseState, await sessionService.require(baseState.sessionId), includeThinkingLevels) as DecoratedSessionState;
 }
 
-function formatSlashCommandList(commands: WebSlashCommandInfo[]) {
-  const groups: Array<[string, string]> = [["web", "Web"], ["extension", "Extensions"], ["prompt", "Prompts"], ["skill", "Skills"]];
-  const lines: string[] = ["Available slash commands:"];
-  for (const [source, label] of groups) {
-    const matching = commands.filter((command) => command.source === source);
-    if (!matching.length) continue;
-    lines.push("", `${label}:`);
-    for (const command of matching) {
-      lines.push(`/${command.name}${command.description ? ` - ${command.description}` : ""}`);
-    }
-  }
-  return lines.join("\n");
+const decorateMessages = (messages: Parameters<typeof decorateHostMessages>[0], sessionFile: string) =>
+  decorateHostMessages(messages, sessionFile, sessionActivity);
+
+function decorateSessionInfos(infos: SessionInfoDto[]) {
+  return infos.map(({ path, ...info }) => ({ ...info, runtime: sessionActivity.runtimeForPath(path) }));
 }
-
-function slashHelp(targetSession: PiWebSession = session) {
-  return [
-    "Type / in the composer to browse available commands.",
-    "",
-    "Web commands run in pi-web; extension, prompt, and skill commands are discovered from pi's extension/resource system.",
-    "",
-    formatSlashCommandList(getSlashCommands(targetSession)),
-  ].join("\n");
-}
-
-function formatModelList(targetSession: PiWebSession = session) {
-  return getAvailableModels(targetSession)
-    .map((model: any) => `${model.provider}/${model.id}${model.name && model.name !== model.id ? ` (${model.name})` : ""}`)
-    .join("\n");
-}
-
-async function executeSlashCommand(input: string, targetSession: PiWebSession = session) {
-  const trimmed = input.trim();
-  const [rawName = "", ...rest] = trimmed.replace(/^\/+/, "").split(/\s+/);
-  const name = rawName.toLowerCase();
-  const args = rest.join(" ").trim();
-
-  switch (name) {
-    case "help":
-    case "?":
-      return { message: slashHelp(targetSession), state: currentStateWithThinkingLevels(targetSession) };
-
-    case "commands":
-      return { message: formatSlashCommandList(getSlashCommands(targetSession)), state: currentStateWithThinkingLevels(targetSession) };
-
-    case "reload": {
-      if (targetSession.isStreaming) throw new Error("Wait for the current response to finish before reloading.");
-      if (targetSession.isCompacting) throw new Error("Wait for compaction to finish before reloading.");
-      if (typeof targetSession.reload !== "function") throw new Error("Reload is not available in this session.");
-      await targetSession.reload();
-      return { message: "Reloaded pi resources, extensions, and models.", state: currentStateWithThinkingLevels(targetSession) };
-    }
-
-    case "model": {
-      if (!args) {
-        return { message: formatModelList(targetSession) || "No models available.", state: currentStateWithThinkingLevels(targetSession) };
-      }
-      const slashIndex = args.indexOf("/");
-      if (slashIndex <= 0) throw new Error("Usage: /model <provider/model-id>");
-      const provider = args.slice(0, slashIndex);
-      const id = args.slice(slashIndex + 1);
-      const model = targetSession.modelRuntime.getModel(provider, id);
-      if (!model) throw new Error(`Model not found: ${args}`);
-      await targetSession.setModel(model);
-      return { message: `Model set to ${provider}/${id}.`, state: currentStateWithThinkingLevels(targetSession) };
-    }
-
-    case "models":
-      return { message: formatModelList(targetSession) || "No models available.", state: currentStateWithThinkingLevels(targetSession) };
-
-    case "thinking": {
-      if (!args) {
-        return { message: `Thinking level: ${targetSession.thinkingLevel}\nAvailable: ${targetSession.getAvailableThinkingLevels().join(", ")}`, state: currentStateWithThinkingLevels(targetSession) };
-      }
-      const levels = targetSession.getAvailableThinkingLevels();
-      if (!levels.includes(args as any)) throw new Error(`Unknown thinking level: ${args}. Available: ${levels.join(", ")}`);
-      targetSession.setThinkingLevel(args as any);
-      return { message: `Thinking level set to ${targetSession.thinkingLevel}.`, state: currentStateWithThinkingLevels(targetSession) };
-    }
-
-    case "new": {
-      const newSession = await createNewLiveSession(sessionCwd(targetSession), targetSession.sessionFile);
-      return { message: "New session.", state: currentStateWithThinkingLevels(newSession) };
-    }
-
-    case "clear": {
-      if (targetSession.isStreaming) throw new Error("Wait for the current response to finish before clearing.");
-      if (targetSession.isCompacting) throw new Error("Wait for compaction to finish before clearing.");
-      const oldSessionId = targetSession.sessionId;
-      const newSession = await createNewLiveSession(sessionCwd(targetSession), targetSession.sessionFile);
-      const state = currentStateWithThinkingLevels(newSession);
-      const sessionUiState = await transferCurrentTabUiState(oldSessionId, newSession.sessionId, state.sessionTitle || "New session", state.cwd);
-      return { message: "Cleared tab. Previous session remains in history.", state: { ...state, sessionUiState } };
-    }
-
-    case "compact": {
-      if (targetSession.isStreaming) throw new Error("Wait for the current response to finish before compacting.");
-      if (targetSession.isCompacting) throw new Error("Compaction is already running.");
-      if (typeof targetSession.compact !== "function") throw new Error("Compaction is not available in this session.");
-      sessionActivity.ensureStarted(targetSession);
-      const releaseWorkLease = acquireWorkLease(targetSession);
-      void targetSession.compact(args || undefined).catch((error: unknown) => {
-        sessionActivity.clearStarted(targetSession);
-        broadcast({
-          type: "server_error",
-          sessionId: targetSession.sessionId,
-          sessionFile: targetSession.sessionFile,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }).finally(releaseWorkLease);
-      return { message: "Compaction started.", state: currentStateWithThinkingLevels(targetSession) };
-    }
-
-    case "abort":
-    case "stop":
-      await targetSession.abort();
-      return { message: "Aborted.", state: currentStateWithThinkingLevels(targetSession) };
-
-    default:
-      throw new Error(`Unknown slash command: /${name}. Try /help.`);
-  }
-}
-
-async function findSessionInfoById(id: string, cwd?: string) {
-  if (!id) return undefined;
-  if (noSession) return undefined;
-  if (mockMode) return mockSessions.find((info) => info.id === id);
-
-  if (cwd && cwd.trim()) {
-    const resolvedCwd = resolve(cwd);
-    const sessionInfo = (await SessionManager.list(resolvedCwd)).find((info) => info.id === id);
-    if (sessionInfo?.cwd) knownCwds.add(sessionInfo.cwd);
-    if (sessionInfo) return sessionInfo;
-  }
-
-  for (const knownCwd of knownCwds) {
-    const sessionInfo = (await SessionManager.list(knownCwd)).find((info) => info.id === id);
-    if (sessionInfo?.cwd) knownCwds.add(sessionInfo.cwd);
-    if (sessionInfo) return sessionInfo;
-  }
-
-  const sessionInfo = (await SessionManager.listAll()).find((info) => info.id === id);
-  if (sessionInfo?.cwd) knownCwds.add(sessionInfo.cwd);
-  return sessionInfo;
-}
-
-async function trashOrRemoveSessionFile(path: string) {
-  try {
-    await execFileAsync("trash", [path], { timeout: 15_000 });
-    return "trashed" as const;
-  } catch (error: any) {
-    if (error?.code !== "ENOENT") throw error;
-    await rm(path, { force: true });
-    return "deleted" as const;
-  }
-}
-
-async function deleteSessionById(id: string, cwd?: string) {
-  if (noSession) throw new Error("Sessions are disabled.");
-
-  const info = await findSessionInfoById(id, cwd);
-  if (!info) {
-    const error = new Error("Session not found");
-    (error as any).status = 404;
-    throw error;
-  }
-
-  const live = liveSessions.get(info.path);
-  if (live?.session?.isStreaming || live?.session?.isCompacting) {
-    const error = new Error("Wait for the session to finish before deleting it.");
-    (error as any).status = 409;
-    throw error;
-  }
-
-  if (live) await disposeLiveSession(info.path, "delete", true);
-
-  if (mockMode) {
-    const index = mockSessions.findIndex((item) => item.id === id);
-    if (index >= 0) mockSessions.splice(index, 1);
-    return { id, disposition: "deleted" as const };
-  }
-
-  return { id, disposition: await trashOrRemoveSessionFile(info.path) };
-}
-
-function liveSessionById(id: string) {
-  if (id === session.sessionId) return session;
-  return liveById.get(id);
-}
-
-function defaultSessionDir(cwd: string) {
-  const resolvedCwd = resolve(cwd);
-  const safePath = `--${resolvedCwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
-  return join(getAgentDir(), "sessions", safePath);
-}
-
-async function resolveSessionLocation(id: string, cwd = piCwd) {
-  if (!id || noSession) return undefined;
-  if (mockMode) {
-    const info = mockSessions.find((item) => item.id === id);
-    if (info) rememberSessionLocation(info as any, info.cwd || cwd);
-    return info ? sessionLocations.get(id) : undefined;
-  }
-
-  const candidateCwds = new Set([resolve(cwd), ...knownCwds]);
-  const suffix = `_${id}.jsonl`;
-  for (const resolvedCwd of candidateCwds) {
-    const directory = defaultSessionDir(resolvedCwd);
-    let names: string[];
-    try { names = await readdir(directory); } catch { continue; }
-    const name = names.find((entry) => entry.endsWith(suffix));
-    if (!name) continue;
-    const location = { path: join(directory, name), cwd: resolvedCwd };
-    sessionLocations.set(id, location);
-    knownCwds.add(resolvedCwd);
-    return location;
-  }
-  return undefined;
-}
-
-async function openSessionAtLocation(id: string, location: { path: string; cwd: string }) {
-  if (!mockMode && dirname(resolve(location.path)) !== defaultSessionDir(location.cwd)) throw new Error("Invalid session location");
-  const target = await getOrCreateLiveSession(location.path);
-  if (target.sessionId !== id) {
-    if (target !== session) await disposeLiveSession(sessionPathKey(target), "reset", true);
-    throw new Error("Session location did not match requested ID");
-  }
-  sessionLocations.set(id, { path: resolve(location.path), cwd: resolve(location.cwd) });
-  return target;
-}
-
-async function getOrCreateLiveSessionById(id: string, cwd?: string) {
-  const existing = liveSessionById(id);
-  if (existing) return existing;
-  const pending = openingById.get(id);
-  if (pending) return pending;
-
-  const opening = (async () => {
-    const remembered = sessionLocations.get(id);
-    if (remembered) {
-      try { return await openSessionAtLocation(id, remembered); }
-      catch { sessionLocations.delete(id); }
-    }
-    const resolved = await resolveSessionLocation(id, cwd);
-    return resolved ? openSessionAtLocation(id, resolved) : undefined;
-  })();
-  openingById.set(id, opening);
-  try { return await opening; }
-  finally { openingById.delete(id); }
-}
-
-async function switchToSessionId(id: string, cwd?: string) {
-  const target = await getOrCreateLiveSessionById(id, cwd);
-  if (!target) throw new Error("Session not found");
-  return target;
-}
-
-const modelRuntime = await ModelRuntime.create();
-const settingsStore = createSettingsStore(process.env.PI_WEB_SETTINGS_FILE || join(getAgentDir(), "pi-web-settings.json"));
-const sessionUiStateStore = createSessionUiStateStore(process.env.PI_WEB_SESSION_UI_STATE_FILE || join(getAgentDir(), "pi-web-session-ui-state.json"));
-type LiveSessionEntry = {
-  session: any;
-  unsubscribe?: () => void;
-  viewerClientIds: Set<string>;
-  workLeases: number;
-  disposeTimer?: ReturnType<typeof setTimeout>;
-  disposing?: boolean;
-};
-
-type ViewerLease = {
-  sessionKey: string;
-  sockets: Set<WebSocket>;
-  releaseTimer?: ReturnType<typeof setTimeout>;
-};
 
 function envMs(name: string, fallback: number) {
   const raw = Number(process.env[name] || fallback);
   return Number.isFinite(raw) && raw >= 0 ? raw : fallback;
 }
 
-const defaultSessionIdleGraceMs = 24 * 60 * 60 * 1000;
-const sessionIdleGraceMs = envMs("PI_WEB_SESSION_IDLE_GRACE_MS", defaultSessionIdleGraceMs);
-const viewerLeaseGraceMs = envMs("PI_WEB_VIEWER_LEASE_GRACE_MS", Math.min(30_000, sessionIdleGraceMs));
+const modelRuntime = await ModelRuntime.create();
+const settingsStore = createSettingsStore(process.env.PI_WEB_SETTINGS_FILE || join(getAgentDir(), "pi-web-settings.json"));
+const sessionUiStateStore = createSessionUiStateStore(process.env.PI_WEB_SESSION_UI_STATE_FILE || join(getAgentDir(), "pi-web-session-ui-state.json"));
+let sessionService: LocalSessionService;
+const sessionActivity = new SessionActivity((path) => sessionService?.sessionForPath(path));
+let session: PiWebSession;
+
 const websocketHeartbeatMs = envMs("PI_WEB_WS_HEARTBEAT_MS", 30_000);
 const websocketMaxMissedHeartbeats = Math.max(1, Math.floor(envMs("PI_WEB_WS_MAX_MISSED_HEARTBEATS", 3)));
-const liveSessions = new Map<string, LiveSessionEntry>();
-const liveById = new Map<string, PiWebSession>();
-const extensionLoaders = new WeakMap<object, ResilientResourceLoader>();
-const sessionLocations = new Map<string, { path: string; cwd: string }>();
-const openingById = new Map<string, Promise<PiWebSession | undefined>>();
-const viewerLeases = new Map<string, ViewerLease>();
-const sessionActivity = new SessionActivity((path) => liveSessions.get(path)?.session);
-let session: PiWebSession;
-let modelFallbackMessage: string | undefined;
-
-type PendingPromptCorrelation = {
-  clientMessageId: string;
-  sourceClientId: string;
-  createdAt: number;
-};
-const pendingPromptCorrelations = new Map<string, PendingPromptCorrelation[]>();
-
-function userMessageFromEvent(event: any) {
-  const value = event?.message;
-  const message = value?.message && typeof value.message === "object" ? value.message : value;
-  const raw = message?.raw || message;
-  return String(message?.role || raw?.role || "") === "user" ? raw : undefined;
-}
-
-function takePromptCorrelation(sessionKey: string, event: any) {
-  if (event?.type !== "message_end" || !userMessageFromEvent(event)) return undefined;
-  const pending = pendingPromptCorrelations.get(sessionKey);
-  if (!pending?.length) return undefined;
-  const cutoff = Date.now() - 60 * 60 * 1000;
-  while (pending[0] && pending[0].createdAt < cutoff) pending.shift();
-  const match = pending.shift();
-  if (!pending.length) pendingPromptCorrelations.delete(sessionKey);
-  return match;
-}
-
-function rememberPromptCorrelation(sessionKey: string, correlation: PendingPromptCorrelation) {
-  const pending = pendingPromptCorrelations.get(sessionKey) || [];
-  pending.push(correlation);
-  pendingPromptCorrelations.set(sessionKey, pending);
-}
-
-function forgetPromptCorrelation(sessionKey: string, clientMessageId: string) {
-  const pending = pendingPromptCorrelations.get(sessionKey)?.filter((item) => item.clientMessageId !== clientMessageId) || [];
-  if (pending.length) pendingPromptCorrelations.set(sessionKey, pending);
-  else pendingPromptCorrelations.delete(sessionKey);
-}
-
 let realtimeHub: RealtimeHub;
 const unreadTracker = new SessionUnreadTracker(sessionUiStateStore, sessionActivity, (value) => realtimeHub.broadcast(value));
 realtimeHub = new RealtimeHub(websocketHeartbeatMs, websocketMaxMissedHeartbeats, (value) => unreadTracker.handle(value));
 
+const mockPromptCorrelations = new Map<string, Array<{ clientMessageId: string; sourceClientId: string }>>();
 function broadcast(value: unknown) {
-  if (value && typeof value === "object" && (value as any).type === "pi_event") {
+  if (mockMode && value && typeof value === "object" && (value as any).type === "pi_event") {
     const envelope = value as Record<string, any>;
-    const correlation = takePromptCorrelation(String(envelope.sessionFile || envelope.sessionId || ""), envelope.event);
-    realtimeHub.broadcast({
-      ...envelope,
-      ...(correlation ? { clientMessageId: correlation.clientMessageId, sourceClientId: correlation.sourceClientId } : {}),
-    });
-    return;
+    const eventMessage = envelope.event?.message;
+    const raw = eventMessage?.message && typeof eventMessage.message === "object" ? eventMessage.message : eventMessage;
+    if (envelope.event?.type === "message_end" && String(raw?.role || raw?.raw?.role || "") === "user") {
+      const key = String(envelope.sessionFile || envelope.sessionId || "");
+      const pending = mockPromptCorrelations.get(key);
+      const correlation = pending?.shift();
+      if (pending && pending.length === 0) mockPromptCorrelations.delete(key);
+      if (correlation) return realtimeHub.broadcast({ ...envelope, ...correlation });
+    }
   }
   realtimeHub.broadcast(value);
 }
 
-function markSessionUnreadCompleted(sessionId: string, unreadAt = new Date().toISOString()) {
-  unreadTracker.markCompleted(sessionId, unreadAt);
-}
-
-function clearSessionUnread(sessionId: string) {
-  unreadTracker.clear(sessionId);
-}
-
-const mockHarness = createMockHarness({
-  piCwd,
-  broadcast,
-  isCurrentSession: (value: PiWebSession) => value === session,
-  currentState,
-});
-const { mockSessions, createMockSession, resetMockSessions, getMockLifecycle } = mockHarness;
-
-function sessionPathKey(value: any) {
-  return String(value.sessionFile || value.sessionId || "");
-}
+function markSessionUnreadCompleted(sessionId: string, unreadAt = new Date().toISOString()) { unreadTracker.markCompleted(sessionId, unreadAt); }
+function clearSessionUnread(sessionId: string) { unreadTracker.clear(sessionId); }
 
 function cleanClientId(value: unknown) {
   if (typeof value !== "string") return "";
@@ -814,343 +225,29 @@ function clientIdFromRequest(req: IncomingMessage, fallback?: unknown) {
   return cleanClientId(headerValue) || cleanClientId(fallback);
 }
 
-function clearTimer(timer: ReturnType<typeof setTimeout> | undefined) {
-  if (timer) clearTimeout(timer);
-}
-
-function cancelLiveSessionCleanup(entry: LiveSessionEntry) {
-  clearTimer(entry.disposeTimer);
-  entry.disposeTimer = undefined;
-}
-
-function isLiveSessionBusy(entry: LiveSessionEntry) {
-  return Boolean(entry.session?.isStreaming || entry.session?.isCompacting || entry.workLeases > 0);
-}
-
-function shouldKeepLiveSession(entry: LiveSessionEntry) {
-  return entry.session === session || entry.viewerClientIds.size > 0 || isLiveSessionBusy(entry);
-}
-
-function scheduleLiveSessionCleanup(key: string) {
-  const entry = liveSessions.get(key);
-  if (!entry || entry.disposing) return;
-  if (shouldKeepLiveSession(entry)) {
-    cancelLiveSessionCleanup(entry);
-    return;
-  }
-  if (entry.disposeTimer) return;
-  entry.disposeTimer = setTimeout(() => {
-    entry.disposeTimer = undefined;
-    void disposeLiveSession(key, "idle");
-  }, sessionIdleGraceMs);
-}
-
-async function emitSessionShutdown(value: any) {
-  const runner = value?.extensionRunner;
-  if (!runner?.hasHandlers?.("session_shutdown")) return;
-  await runner.emit({ type: "session_shutdown", reason: "quit" });
-}
-
-async function disposeLiveSession(key: string, reason: "idle" | "delete" | "reset" = "idle", force = false) {
-  const entry = liveSessions.get(key);
-  if (!entry || entry.disposing) return;
-  if (!force && shouldKeepLiveSession(entry)) return;
-
-  entry.disposing = true;
-  cancelLiveSessionCleanup(entry);
-  const value = entry.session;
-  const sessionId = String(value?.sessionId || "");
-  const sessionFile = String(value?.sessionFile || key || "");
-
-  for (const [clientId, lease] of viewerLeases) {
-    if (lease.sessionKey !== key) continue;
-    clearTimer(lease.releaseTimer);
-    viewerLeases.delete(clientId);
-  }
-
-  try {
-    await emitSessionShutdown(value);
-  } catch (error) {
-    console.warn(`Could not emit session shutdown before ${reason}:`, error);
-  }
-
-  try {
-    entry.unsubscribe?.();
-  } catch (error) {
-    console.warn(`Could not unsubscribe session before ${reason}:`, error);
-  }
-
-  try {
-    value?.dispose?.();
-  } catch (error) {
-    console.warn(`Could not dispose session after ${reason}:`, error);
-  }
-
-  liveSessions.delete(key);
-  pendingPromptCorrelations.delete(key);
-  if (liveById.get(sessionId) === value) liveById.delete(sessionId);
-  sessionActivity.clearSession(key, value);
-
-  if (sessionId) {
-    broadcast({ type: "session_runtime_changed", sessionId, sessionFile, runtime: sessionActivity.runtimeForPath(sessionFile) });
-  }
-}
-
-function scheduleViewerLeaseRelease(clientId: string) {
-  const lease = viewerLeases.get(clientId);
-  if (!lease || lease.sockets.size > 0) return;
-  clearTimer(lease.releaseTimer);
-  lease.releaseTimer = setTimeout(() => releaseViewerLease(clientId), viewerLeaseGraceMs);
-}
-
-function releaseViewerLease(clientId: string) {
-  const lease = viewerLeases.get(clientId);
-  if (!lease) return;
-  clearTimer(lease.releaseTimer);
-  viewerLeases.delete(clientId);
-  const entry = liveSessions.get(lease.sessionKey);
-  if (entry) {
-    entry.viewerClientIds.delete(clientId);
-    scheduleLiveSessionCleanup(lease.sessionKey);
-  }
-}
-
-function acquireViewerLease(clientId: string, value: any) {
-  if (!clientId || !value) return undefined;
-  const key = sessionPathKey(value);
-  const entry = liveSessions.get(key);
-  if (!key || !entry) return undefined;
-
-  let lease = viewerLeases.get(clientId);
-  const sockets = lease?.sockets || new Set<WebSocket>();
-  clearTimer(lease?.releaseTimer);
-  if (lease && lease.sessionKey !== key) {
-    const previous = liveSessions.get(lease.sessionKey);
-    previous?.viewerClientIds.delete(clientId);
-    scheduleLiveSessionCleanup(lease.sessionKey);
-  }
-
-  lease = { sessionKey: key, sockets };
-  viewerLeases.set(clientId, lease);
-  entry.viewerClientIds.add(clientId);
-  cancelLiveSessionCleanup(entry);
-  if (sockets.size === 0) scheduleViewerLeaseRelease(clientId);
-  return lease;
+function noteViewerLeaseFromRequest(req: IncomingMessage, value: PiWebSession, fallbackClientId?: unknown) {
+  const clientId = clientIdFromRequest(req, fallbackClientId);
+  if (clientId) sessionService.acquireViewer(value.sessionId, clientId);
 }
 
 function bindViewerSocket(clientId: string, ws: WebSocket) {
-  const lease = viewerLeases.get(clientId);
-  if (!lease) return;
-  clearTimer(lease.releaseTimer);
-  lease.releaseTimer = undefined;
-  lease.sockets.add(ws);
-  ws.on("close", () => {
-    const current = viewerLeases.get(clientId);
-    current?.sockets.delete(ws);
-    if (!current || current.sockets.size > 0) return;
-    releaseViewerLease(clientId);
-  });
+  const connection = sessionService.connectViewer(clientId);
+  if (connection) ws.on("close", () => sessionService.disconnectViewer(connection));
 }
 
-function noteViewerLeaseFromRequest(req: IncomingMessage, value: any, fallbackClientId?: unknown) {
-  const clientId = clientIdFromRequest(req, fallbackClientId);
-  if (clientId) acquireViewerLease(clientId, value);
-}
-
-function acquireWorkLease(value: any) {
-  const key = sessionPathKey(value);
-  const entry = liveSessions.get(key);
-  if (!entry) return () => undefined;
-  entry.workLeases++;
-  cancelLiveSessionCleanup(entry);
-  let released = false;
-  return () => {
-    if (released) return;
-    released = true;
-    entry.workLeases = Math.max(0, entry.workLeases - 1);
-    scheduleLiveSessionCleanup(key);
-  };
-}
-
-function registerLiveSession(value: any) {
-  const key = sessionPathKey(value);
-  if (!key || liveSessions.get(key)?.session === value) return value;
-
-  const unsubscribe = value.subscribe?.((event: unknown) => {
-    const e = event as any;
-    const enriched = sessionActivity.enrichEvent(value, event);
-    const eventSessionFile = enriched.sessionFile;
-    const eventSessionId = enriched.sessionId;
-    const eventForClient = enriched.event;
-
-    // Track models that fail with model_not_supported and remove them from the list.
-
-    broadcast({ type: "pi_event", sessionId: eventSessionId, sessionFile: eventSessionFile, event: eventForClient });
-    broadcast({
-      type: "session_runtime_changed",
-      sessionId: eventSessionId,
-      sessionFile: eventSessionFile,
-      runtime: sessionActivity.runtimeForEvent(eventSessionFile, e),
-    });
-
-    // Broadcast state update when session name changes
-    if (e?.type === "session_info_changed") {
-      broadcast({ type: "state_changed", ...currentState(value) });
-    }
-
-    if (e?.type === "message_end" || e?.type === "agent_end" || e?.type === "compaction_end") {
-      broadcast({ type: "session_stats_changed", sessionId: eventSessionId, sessionFile: eventSessionFile, stats: sessionStats(value) });
-    }
-
-    if (e?.type === "message_end" || e?.type === "turn_end") {
-      const msg = e?.message ?? e?.toolResults?.[0];
-      const err: string = msg?.errorMessage || msg?.message?.errorMessage || "";
-      const modelId: string = msg?.model || msg?.message?.model || "";
-      if (modelId && (err.includes("model_not_supported") || err.includes("model_not_available"))) {
-        if (!blockedModelIds.has(modelId)) {
-          blockedModelIds.add(modelId);
-          broadcast({ type: "models_updated", sessionId: eventSessionId, models: getAvailableModels(value).map(simplifyModel) });
-        }
-      }
-    }
-  });
-  liveSessions.set(key, { session: value, unsubscribe, viewerClientIds: new Set(), workLeases: 0 });
-  liveById.set(value.sessionId, value);
-  if (value.sessionFile) sessionLocations.set(value.sessionId, { path: resolve(value.sessionFile), cwd: sessionCwd(value) });
-  queueMicrotask(() => scheduleLiveSessionCleanup(key));
-  return value;
-}
+const mockHarness = createMockHarness({
+  piCwd,
+  broadcast,
+  isCurrentSession: (value: PiWebSession) => value === session,
+  currentState,
+});
+const { mockSessions, createMockSession, resetMockSessions, getMockLifecycle } = mockHarness;
 
 function additionalExtensionPaths(cwd = piCwd) {
   return [
     ...resolveBundledExtensionPaths({ piCwd: cwd, appDir, bundledExtensionsDir }),
     ...resolvePiWebExtensionPaths(cwd),
   ];
-}
-
-async function makeAgentSession(path?: string, sessionStartEvent?: SessionStartEvent, cwd = piCwd) {
-  if (mockMode) return { session: createMockSession(path), modelFallbackMessage: undefined };
-
-  const targetCwd = await assertDirectory(cwd, piCwd);
-  const sessionManager = noSession
-    ? SessionManager.inMemory(targetCwd)
-    : path
-      ? SessionManager.open(path)
-      : SessionManager.create(targetCwd);
-  if (!path && !noSession && sessionStartEvent?.reason === "new") sessionManager.newSession();
-
-  const resolvedCwd = sessionCwd({ sessionManager });
-  knownCwds.add(resolvedCwd);
-  await ensurePiWebStorage(resolvedCwd);
-
-  const webUiContext = existsSync(webUiContextFile) ? readFileSync(webUiContextFile, "utf-8") : "";
-
-  const loader = new ResilientResourceLoader({
-    loadTimeoutMs: envMs("PI_WEB_EXTENSION_LOAD_TIMEOUT_MS", 8_000),
-    fetchTimeoutMs: envMs("PI_WEB_EXTENSION_FETCH_TIMEOUT_MS", 3_000),
-    loaderOptions: {
-      cwd: resolvedCwd,
-      agentDir: getAgentDir(),
-      additionalExtensionPaths: additionalExtensionPaths(resolvedCwd),
-      appendSystemPromptOverride: (base) => [
-        ...base,
-        webUiContext,
-      ].filter(Boolean),
-    },
-  });
-  await loader.reload();
-
-  const result = await createAgentSession({
-    cwd: resolvedCwd,
-    sessionManager,
-    modelRuntime,
-    resourceLoader: loader,
-    sessionStartEvent,
-  });
-  extensionLoaders.set(result.session, loader);
-  await webUiBridge.bind(result.session);
-  return result;
-}
-
-function openExtensionSession(requestedSessionId?: string): PiWebSession {
-  const id = requestedSessionId?.trim() || session.sessionId;
-  const value = id === session.sessionId ? session : liveById.get(id);
-  if (!value) throw new SessionServiceError("Session is not currently open.", 404);
-  return value;
-}
-
-function extensionStatusForSession(requestedSessionId?: string) {
-  const loader = extensionLoaders.get(openExtensionSession(requestedSessionId));
-  if (!loader) throw new SessionServiceError("Extension status is not available for this session.", 404);
-  return loader.getStatus();
-}
-
-async function reloadExtensionsForSession(requestedSessionId?: string) {
-  const value = openExtensionSession(requestedSessionId);
-  if (value.isStreaming) throw new SessionServiceError("Wait for the current response to finish before retrying extensions.", 409);
-  if (value.isCompacting) throw new SessionServiceError("Wait for compaction to finish before retrying extensions.", 409);
-  const loader = extensionLoaders.get(value);
-  if (!loader || typeof value.reload !== "function") {
-    throw new SessionServiceError("Extension reload is not available for this session.", 404);
-  }
-  await value.reload();
-  const status = loader.getStatus();
-  broadcast({ type: "extensions_reloaded", sessionId: value.sessionId, status });
-  return status;
-}
-
-async function getOrCreateLiveSession(path: string) {
-  const existing = liveSessions.get(path)?.session;
-  if (existing) {
-    scheduleLiveSessionCleanup(path);
-    return existing;
-  }
-  const created = await makeAgentSession(path);
-  if (created.modelFallbackMessage) console.warn(created.modelFallbackMessage);
-  return registerLiveSession(created.session);
-}
-
-async function applyDefaultSessionSettings(value: any) {
-  const settings = await settingsStore.read();
-  const modelSetting = settings.defaults.model;
-  if (modelSetting) {
-    const model = value.modelRuntime.getModel(modelSetting.provider, modelSetting.id);
-    if (model) await value.setModel(model);
-  }
-  const thinkingLevel = settings.defaults.thinkingLevel;
-  if (thinkingLevel && value.getAvailableThinkingLevels().includes(thinkingLevel as any)) {
-    value.setThinkingLevel(thinkingLevel as any);
-  }
-}
-
-async function applyDefaultSessionBucket(sessionId: string) {
-  const color = (await settingsStore.read()).defaults.sessionBucketColor;
-  if (!sessionId || !color) return undefined;
-  const current = await sessionUiStateStore.read();
-  if (current.sessionMarkers.some((marker) => marker.sessionId === sessionId)) return current;
-  const sessionUiState = await sessionUiStateStore.write({
-    ...current,
-    sessionMarkers: [{ sessionId, color, updatedAt: new Date().toISOString() }, ...current.sessionMarkers],
-  });
-  broadcast({ type: "session_ui_state_changed", sessionUiState });
-  return sessionUiState;
-}
-
-async function createNewLiveSession(cwd?: string, previousSessionFile?: string) {
-  const targetCwd = cwd ? await assertDirectory(cwd, piCwd) : piCwd;
-  knownCwds.add(targetCwd);
-  await ensurePiWebStorage(targetCwd);
-  const created = await makeAgentSession(undefined, { type: "session_start", reason: "new", previousSessionFile }, targetCwd);
-  if (created.modelFallbackMessage) console.warn(created.modelFallbackMessage);
-  const value = created.session;
-  if (mockMode) {
-    value.sessionManager.newSession();
-    value.agent.state.messages = value.sessionManager.buildSessionContext().messages;
-  }
-  await applyDefaultSessionSettings(value);
-  const liveSession = registerLiveSession(value);
-  await applyDefaultSessionBucket(liveSession.sessionId);
-  return liveSession;
 }
 
 async function transferCurrentTabUiState(oldSessionId: string, newSessionId: string, _newLabel: string, cwd: string) {
@@ -1177,131 +274,64 @@ async function transferCurrentTabUiState(oldSessionId: string, newSessionId: str
   return next;
 }
 
-async function switchEmptySessionCwd(targetSession: PiWebSession, cwd: string) {
-  if (targetSession.isStreaming) throw new Error("Wait for the current response to finish before changing the working directory.");
-  if (targetSession.isCompacting) throw new Error("Wait for compaction to finish before changing the working directory.");
-  if (hasUserMessages(targetSession)) throw new Error("Working directory can only be changed before the first message.");
-  const newSession = await createNewLiveSession(cwd, targetSession.sessionFile);
-  return currentStateWithThinkingLevels(newSession);
-}
-
-async function navigateSession(targetSession: PiWebSession, targetId: string, options: Record<string, unknown>) {
-  if (targetSession.isStreaming) throw new SessionServiceError("Wait for the current response to finish before navigating the tree", 409);
-  if (targetSession.isCompacting) throw new SessionServiceError("Wait for the current compaction to finish before navigating the tree", 409);
-  if (!targetSession.navigateTree) throw new SessionServiceError("Tree navigation is not available");
-  const releaseWorkLease = acquireWorkLease(targetSession);
-  let finished = false;
-  const finish = () => {
-    if (finished) return;
-    finished = true;
-    releaseWorkLease();
-    broadcast({ type: "session_runtime_changed", sessionId: targetSession.sessionId, sessionFile: targetSession.sessionFile, runtime: sessionActivity.runtimeForPath(targetSession.sessionFile) });
-  };
-  try {
-    const navigation = targetSession.navigateTree(targetId, options as any);
-    broadcast({ type: "session_runtime_changed", sessionId: targetSession.sessionId, sessionFile: targetSession.sessionFile, runtime: sessionActivity.runtimeForPath(targetSession.sessionFile) });
-    const result = await navigation;
-    const state = currentStateWithThinkingLevels(targetSession);
-    broadcast({ type: "state_changed", ...state });
-    return { ...result, leafId: targetSession.sessionManager.getLeafId?.() || null, state, finish };
-  } catch (error) {
-    finish();
-    throw error;
-  }
-}
-
-async function startSessionPrompt(targetSession: PiWebSession, input: { message: string; mode: string; images: Array<{ data: string; mimeType: string; name?: string }>; clientMessageId?: string; sourceClientId?: string }) {
-  const imageFileNote = await persistPromptImages(input.images, sessionCwd(targetSession));
-  const promptText = `${input.message || "Please review the attached image."}${imageFileNote}`;
-  if (input.clientMessageId && input.sourceClientId) {
-    rememberPromptCorrelation(sessionPathKey(targetSession), {
-      clientMessageId: input.clientMessageId,
-      sourceClientId: input.sourceClientId,
-      createdAt: Date.now(),
-    });
-  }
-  if (!targetSession.isStreaming && !targetSession.isCompacting) sessionActivity.ensureStarted(targetSession);
-  const promptSessionFile = targetSession.sessionFile;
-  const releaseWorkLease = acquireWorkLease(targetSession);
-  void targetSession.prompt(promptText, {
-    ...(targetSession.isStreaming ? { streamingBehavior: input.mode } : {}),
-    ...(input.images.length ? { images: input.images.map(({ data, mimeType }) => ({ type: "image", data, mimeType })) } : {}),
-  }).catch((error: unknown) => {
-    if (input.clientMessageId) forgetPromptCorrelation(sessionPathKey(targetSession), input.clientMessageId);
-    broadcast({ type: "server_error", sessionId: targetSession.sessionId, sessionFile: targetSession.sessionFile, error: error instanceof Error ? error.message : String(error) });
-  })
-    .finally(() => {
-      const isRunning = Boolean(targetSession.isStreaming || targetSession.isCompacting);
-      if (promptSessionFile && sessionActivity.hasStarted(promptSessionFile) && !isRunning) {
-        sessionActivity.clearStarted(targetSession, promptSessionFile);
-        markSessionUnreadCompleted(targetSession.sessionId);
-      }
-      broadcast({ type: "session_runtime_changed", sessionId: targetSession.sessionId, sessionFile: targetSession.sessionFile, runtime: sessionActivity.runtimeForPath(targetSession.sessionFile) });
-      releaseWorkLease();
-    });
-}
-
-async function startSessionRetry(targetSession: PiWebSession) {
-  try { assertCanRetryFromFailure(targetSession); } catch (error) { throw new SessionServiceError(error instanceof Error ? error.message : String(error), 409); }
-  sessionActivity.ensureStarted(targetSession);
-  const retrySessionFile = targetSession.sessionFile;
-  const releaseWorkLease = acquireWorkLease(targetSession);
-  void retrySessionFromFailure(targetSession).catch((error: unknown) => {
-    sessionActivity.clearStarted(targetSession, retrySessionFile);
-    broadcast({ type: "server_error", sessionId: targetSession.sessionId, sessionFile: targetSession.sessionFile, error: error instanceof Error ? error.message : String(error) });
-  }).finally(() => {
-    const isRunning = Boolean(targetSession.isStreaming || targetSession.isCompacting);
-    if (retrySessionFile && sessionActivity.hasStarted(retrySessionFile) && !isRunning) {
-      sessionActivity.clearStarted(targetSession, retrySessionFile);
-      markSessionUnreadCompleted(targetSession.sessionId);
-    }
-    broadcast({ type: "session_runtime_changed", sessionId: targetSession.sessionId, sessionFile: targetSession.sessionFile, runtime: sessionActivity.runtimeForPath(targetSession.sessionFile) });
-    releaseWorkLease();
+async function applyDefaultSessionBucket(sessionId: string) {
+  const color = (await settingsStore.read()).defaults.sessionBucketColor;
+  if (!sessionId || !color) return undefined;
+  const current = await sessionUiStateStore.read();
+  if (current.sessionMarkers.some((marker) => marker.sessionId === sessionId)) return current;
+  const sessionUiState = await sessionUiStateStore.write({
+    ...current,
+    sessionMarkers: [{ sessionId, color, updatedAt: new Date().toISOString() }, ...current.sessionMarkers],
   });
+  broadcast({ type: "session_ui_state_changed", sessionUiState });
+  return sessionUiState;
 }
 
-const webUiBridge = createWebUiBridge({
-  emit: broadcast,
-  clientCount: () => realtimeHub.clientCount,
-  acquireWorkLease,
-  createNewSession: createNewLiveSession,
-  sessionCwd: (value) => sessionCwd(value),
-  state: (value) => currentStateWithThinkingLevels(value),
+const handleSessionServiceEvent = createHostSessionEventHandler({
+  sessionForId: (id) => sessionService.sessionForId(id),
+  projectState: (value) => sessionService.projectState(value),
+  webUiEntries: (value) => sessionService.webUiEntries(value),
+  sessionActivity,
+  broadcast,
+  markSessionUnreadCompleted,
 });
 
-const sessionService = new LocalSessionService({
-  currentSessionId: () => session.sessionId,
+const mockSessionFactory = mockMode ? {
+  isMock: true,
+  create: async ({ path }: { path?: string }) => ({ session: createMockSession(path) }),
+  list: async () => mockSessions,
+  remove: async (id: string) => {
+    const index = mockSessions.findIndex((item) => item.id === id);
+    if (index >= 0) mockSessions.splice(index, 1);
+    return "deleted" as const;
+  },
+} : undefined;
+
+sessionService = new LocalSessionService({
+  modelRuntime,
+  sessionFactory: mockSessionFactory,
+  additionalExtensionPaths,
+  sessionConfig: {
+    defaultsFor: async () => {
+      const defaults = (await settingsStore.read()).defaults;
+      return { model: defaults.model, thinkingLevel: defaults.thinkingLevel };
+    },
+    finalizeCreatedSession: applyDefaultSessionBucket,
+  },
   globalCwd: () => piCwd,
-  resolve: (id) => getOrCreateLiveSessionById(id),
-  cwd: (value) => sessionCwd(value),
-  decorateState: (value) => currentStateWithThinkingLevels(value),
-  decorateMessageContent: (content, sessionFile) => sessionActivity.decorateMessageContent(content, sessionFile),
-  availableModels: (value) => getAvailableModels(value),
-  webCommands: webSlashCommands,
-  list: listSessionInfos,
-  create: createNewLiveSession,
-  open: switchToSessionId,
-  delete: deleteSessionById,
-  switchCwd: switchEmptySessionCwd,
-  executeCommand: executeSlashCommand,
-  prompt: startSessionPrompt,
-  retry: startSessionRetry,
-  navigate: navigateSession,
-  invokeHeaderAction: (value, key) => webUiBridge.invokeHeaderAction(value, key),
-  invokeArtifactAction: (value, input) => webUiBridge.invokeArtifactAction(value, input),
-  invokeGitTab: (value, input) => webUiBridge.invokeGitTab(value, input),
-  reportError: (value, error) => broadcast({ type: "server_error", sessionId: value.sessionId, sessionFile: value.sessionFile, error: error instanceof Error ? error.message : String(error) }),
+  clientCount: () => realtimeHub.clientCount,
+});
+sessionService.subscribe((event) => {
+  if (event.type === "shutdown") {
+    mockPromptCorrelations.delete(event.sessionKey);
+    mockPromptCorrelations.delete(event.sessionFile);
+    mockPromptCorrelations.delete(event.sessionId);
+  }
+  handleSessionServiceEvent(event);
 });
 
 await ensurePiWebStorage();
-
-const createdSession = await makeAgentSession();
-session = registerLiveSession(createdSession.session);
-modelFallbackMessage = createdSession.modelFallbackMessage;
-
-if (modelFallbackMessage) {
-  console.warn(modelFallbackMessage);
-}
+session = await sessionService.initialize();
 
 let viteDevServer: ViteDevServer | undefined;
 
@@ -1318,35 +348,19 @@ const server = createServer(async (req, res) => {
       if (!isAuthorized(req)) return unauthorized(res);
 
       if (mockMode && method === "POST" && url.pathname === "/api/mock/reset") {
-        await Promise.all(Array.from(liveSessions.keys()).map((key) => disposeLiveSession(key, "reset", true)));
+        await sessionService.disposeAll("reset");
+        mockPromptCorrelations.clear();
         resetMockSessions();
         await sessionUiStateStore.write(defaultSessionUiState);
-        session = registerLiveSession(createMockSession());
+        session = createMockSession();
+        sessionService.setCurrentSession(session);
         broadcast({ type: "session_ui_state_changed", sessionUiState: defaultSessionUiState });
         broadcast({ type: "state_changed", ...currentState() });
         return sendJson(res, 200, { ok: true });
       }
 
       if (mockMode && method === "GET" && url.pathname === "/api/mock/live-sessions") {
-        return sendJson(res, 200, {
-          ok: true,
-          liveSessions: Array.from(liveSessions.values()).map((entry) => ({
-            sessionId: String(entry.session?.sessionId || ""),
-            sessionFile: String(entry.session?.sessionFile || ""),
-            viewerLeases: entry.viewerClientIds.size,
-            workLeases: entry.workLeases,
-            hasDisposeTimer: Boolean(entry.disposeTimer),
-            isStreaming: Boolean(entry.session?.isStreaming),
-            isCompacting: Boolean(entry.session?.isCompacting),
-          })),
-          viewerLeases: Array.from(viewerLeases.entries()).map(([clientId, lease]) => ({
-            clientId,
-            sessionKey: lease.sessionKey,
-            sockets: lease.sockets.size,
-            hasReleaseTimer: Boolean(lease.releaseTimer),
-          })),
-          lifecycle: getMockLifecycle(),
-        });
+        return sendJson(res, 200, { ok: true, ...sessionService.lifecycleSnapshot(), lifecycle: getMockLifecycle() });
       }
 
       if (method === "GET" && url.pathname === "/api/fs/dirs") {
@@ -1489,11 +503,11 @@ const server = createServer(async (req, res) => {
       }
 
       if (method === "GET" && url.pathname === "/api/state") {
-        const requestedSessionId = url.searchParams.get("sessionId") || undefined;
+        const requestedSessionId = resolveSessionId(url.searchParams.get("sessionId"));
         noteViewerLeaseFromRequest(req, await sessionService.require(requestedSessionId), url.searchParams.get("clientId"));
         return sendJson(res, 200, {
           ok: true,
-          ...await sessionService.state(requestedSessionId),
+          ...await decorateServiceState(await sessionService.state(requestedSessionId)),
           sessionUiState: await sessionUiStateStore.read(),
           tokenRequired: Boolean(token),
         });
@@ -1502,7 +516,7 @@ const server = createServer(async (req, res) => {
       if (method === "POST" && url.pathname === "/api/web-header-action/invoke") {
         const body = await readBody(req) as { sessionId?: unknown; key?: unknown };
         try {
-          return sendJson(res, 200, { ok: true, ...await sessionService.invokeHeaderAction(typeof body.sessionId === "string" ? body.sessionId : undefined, body.key) });
+          return sendJson(res, 200, { ok: true, ...await sessionService.invokeHeaderAction(resolveSessionId(body.sessionId), body.key) });
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           const status = error instanceof SessionServiceError ? error.status : message === "key is required" || message === "Header action returned no markdown" ? 400 : message === "Header action not found" ? 404 : 500;
@@ -1513,7 +527,7 @@ const server = createServer(async (req, res) => {
       if (method === "POST" && url.pathname === "/api/web-artifact-action/invoke") {
         const body = await readBody(req) as { sessionId?: unknown } & Record<string, unknown>;
         try {
-          return sendJson(res, 200, { ok: true, ...await sessionService.invokeArtifactAction(typeof body.sessionId === "string" ? body.sessionId : undefined, body) });
+          return sendJson(res, 200, { ok: true, ...await sessionService.invokeArtifactAction(resolveSessionId(body.sessionId), body) });
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           const status = error instanceof SessionServiceError ? error.status : message === "Artifact action not found" ? 404 : message === "Invalid artifact context" || message === "Artifact action does not match this artifact" || message === "key is required" || message === "Artifact action returned no result" ? 400 : 500;
@@ -1524,7 +538,7 @@ const server = createServer(async (req, res) => {
       if (method === "POST" && url.pathname === "/api/web-git-tab/invoke") {
         const body = await readBody(req) as { sessionId?: unknown; key?: unknown; action?: unknown; payload?: unknown; repo?: unknown };
         try {
-          return sendJson(res, 200, { ok: true, ...await sessionService.invokeGitTab(typeof body.sessionId === "string" ? body.sessionId : undefined, body) });
+          return sendJson(res, 200, { ok: true, ...await sessionService.invokeGitTab(resolveSessionId(body.sessionId), body) });
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           const status = error instanceof SessionServiceError ? error.status : message === "key is required" || message === "Git tab returned no HTML or composer context" ? 400 : message === "Git tab not found" ? 404 : 500;
@@ -1533,27 +547,28 @@ const server = createServer(async (req, res) => {
       }
 
       if (method === "GET" && url.pathname === "/api/session/stats") {
-        return sendJson(res, 200, { ok: true, ...await sessionService.stats(url.searchParams.get("sessionId") || undefined) });
+        return sendJson(res, 200, { ok: true, ...await sessionService.stats(resolveSessionId(url.searchParams.get("sessionId"))) });
       }
 
       if (method === "GET" && url.pathname === "/api/session/tree") {
-        return sendJson(res, 200, await sessionService.tree(url.searchParams.get("sessionId") || undefined));
+        return sendJson(res, 200, await sessionService.tree(resolveSessionId(url.searchParams.get("sessionId"))));
       }
 
       if (method === "POST" && url.pathname === "/api/session/tree/navigate") {
         const body = await readBody(req) as { sessionId?: unknown; targetId?: unknown; summarize?: unknown; customInstructions?: unknown; replaceInstructions?: unknown; label?: unknown };
-        const requestedSessionId = typeof body.sessionId === "string" ? body.sessionId : undefined;
+        const requestedSessionId = resolveSessionId(body.sessionId);
         await sessionService.require(requestedSessionId);
         const targetId = String(body.targetId || "").trim();
         if (!targetId) return sendJson(res, 400, { ok: false, error: "targetId is required" });
-        const { finish, ...result } = await sessionService.navigate(requestedSessionId, targetId, {
+        const { finish, state: baseState, ...result } = await sessionService.navigate(requestedSessionId, targetId, {
           summarize: Boolean(body.summarize),
           customInstructions: typeof body.customInstructions === "string" && body.customInstructions.trim() ? body.customInstructions.trim() : undefined,
           replaceInstructions: Boolean(body.replaceInstructions),
           label: typeof body.label === "string" && body.label.trim() ? body.label.trim() : undefined,
         });
+        const state = await decorateServiceState(baseState);
         try {
-          return sendJson(res, 200, { ok: true, ...result });
+          return sendJson(res, 200, { ok: true, ...result, state });
         } finally {
           finish();
         }
@@ -1561,17 +576,19 @@ const server = createServer(async (req, res) => {
 
       if (method === "POST" && url.pathname === "/api/session/tree/abort-summary") {
         const body = await readBody(req) as { sessionId?: unknown };
-        return sendJson(res, 202, { ok: true, ...await sessionService.abortBranchSummary(typeof body.sessionId === "string" ? body.sessionId : undefined) });
+        return sendJson(res, 202, { ok: true, ...await sessionService.abortBranchSummary(resolveSessionId(body.sessionId)) });
       }
 
       if (method === "GET" && url.pathname === "/api/messages") {
-        return sendJson(res, 200, { ok: true, messages: await sessionService.messages(url.searchParams.get("sessionId") || undefined) });
+        const requestedSessionId = resolveSessionId(url.searchParams.get("sessionId"));
+        const target = await sessionService.require(requestedSessionId);
+        return sendJson(res, 200, { ok: true, messages: decorateMessages(await sessionService.messages(target.sessionId), target.sessionFile) });
       }
 
       if (method === "GET" && url.pathname === "/api/sessions") {
         const extraCwds = url.searchParams.getAll("cwd");
         const sessionUiState = await sessionUiStateStore.read();
-        return sendJson(res, 200, { ok: true, sessions: applySessionUnreadState(await sessionService.list(extraCwds), sessionUiState) });
+        return sendJson(res, 200, { ok: true, sessions: applySessionUnreadState(decorateSessionInfos(await sessionService.list(extraCwds)), sessionUiState) });
       }
 
       if (method === "GET" && url.pathname === "/api/session-ui-state") {
@@ -1621,20 +638,20 @@ const server = createServer(async (req, res) => {
       }
 
       if (method === "GET" && url.pathname === "/api/extensions/status") {
-        return sendJson(res, 200, { ok: true, status: extensionStatusForSession(url.searchParams.get("sessionId") || undefined) });
+        return sendJson(res, 200, { ok: true, status: sessionService.extensionStatus(resolveSessionId(url.searchParams.get("sessionId"))) });
       }
 
       if (method === "POST" && url.pathname === "/api/extensions/reload") {
         const body = await readBody(req) as { sessionId?: unknown };
-        return sendJson(res, 200, { ok: true, status: await reloadExtensionsForSession(typeof body.sessionId === "string" ? body.sessionId : undefined) });
+        return sendJson(res, 200, { ok: true, status: await sessionService.reloadExtensions(resolveSessionId(body.sessionId)) });
       }
 
       if (method === "GET" && url.pathname === "/api/commands") {
-        return sendJson(res, 200, { ok: true, commands: await sessionService.commands(url.searchParams.get("sessionId") || undefined) });
+        return sendJson(res, 200, { ok: true, commands: await sessionService.commands(resolveSessionId(url.searchParams.get("sessionId"))) });
       }
 
       if (method === "GET" && url.pathname === "/api/models") {
-        return sendJson(res, 200, { ok: true, ...await sessionService.models(url.searchParams.get("sessionId") || undefined) });
+        return sendJson(res, 200, { ok: true, ...await sessionService.models(resolveSessionId(url.searchParams.get("sessionId"))) });
       }
 
       if (method === "POST" && url.pathname === "/api/model") {
@@ -1642,7 +659,7 @@ const server = createServer(async (req, res) => {
         const provider = String(body.provider || "").trim();
         const id = String(body.id || "").trim();
         if (!provider || !id) return sendJson(res, 400, { ok: false, error: "provider and id are required" });
-        const state = await sessionService.setModel(typeof body.sessionId === "string" ? body.sessionId : undefined, provider, id, typeof body.thinkingLevel === "string" ? body.thinkingLevel : undefined);
+        const state = await decorateServiceState(await sessionService.setModel(resolveSessionId(body.sessionId), provider, id, typeof body.thinkingLevel === "string" ? body.thinkingLevel : undefined));
         broadcast({ type: "state_changed", ...state });
         return sendJson(res, 200, { ok: true, ...state });
       }
@@ -1652,25 +669,29 @@ const server = createServer(async (req, res) => {
         const command = String(body.command || "").trim();
         if (!command.startsWith("/")) return sendJson(res, 400, { ok: false, error: "Slash command is required" });
 
-        const result = await sessionService.executeCommand(typeof body.sessionId === "string" ? body.sessionId : undefined, command);
-        const stateSessionId = (result as any)?.state?.sessionId;
-        const stateSession = typeof stateSessionId === "string" ? await getOrCreateLiveSessionById(stateSessionId) : undefined;
-        noteViewerLeaseFromRequest(req, stateSession || await sessionService.require(typeof body.sessionId === "string" ? body.sessionId : undefined));
-        return sendJson(res, 200, { ok: true, ...result });
+        const target = await sessionService.require(resolveSessionId(body.sessionId));
+        const result = await sessionService.executeCommand(target.sessionId, command);
+        const created = result.state.sessionId !== target.sessionId;
+        const decorated = await decorateServiceState(result.state);
+        const state = created && /^\/+clear(?:\s|$)/i.test(command)
+          ? { ...decorated, sessionUiState: await transferCurrentTabUiState(target.sessionId, decorated.sessionId, decorated.sessionTitle || "New session", decorated.cwd) }
+          : decorated;
+        noteViewerLeaseFromRequest(req, await sessionService.require(state.sessionId));
+        return sendJson(res, 200, { ok: true, message: result.message, state });
       }
 
       if (method === "POST" && url.pathname === "/api/shell") {
         const body = await readBody(req) as { sessionId?: unknown; command?: unknown; excludeFromContext?: unknown };
         const command = String(body.command || "").trim();
         if (!command) return sendJson(res, 400, { ok: false, error: "command is required" });
-        return sendJson(res, 200, { ok: true, ...await sessionService.executeShell(typeof body.sessionId === "string" ? body.sessionId : undefined, command, Boolean(body.excludeFromContext)) });
+        return sendJson(res, 200, { ok: true, ...await sessionService.executeShell(resolveSessionId(body.sessionId), command, Boolean(body.excludeFromContext)) });
       }
 
       if (method === "POST" && url.pathname === "/api/extension-ui/respond") {
         const body = await readBody(req) as { id?: unknown } & Record<string, unknown>;
         const id = String(body.id || "").trim();
         if (!id) return sendJson(res, 400, { ok: false, error: "id is required" });
-        if (!webUiBridge.respond(id, body)) return sendJson(res, 404, { ok: false, error: "Extension UI request not found" });
+        if (!sessionService.respondExtensionUi(id, body)) return sendJson(res, 404, { ok: false, error: "Extension UI request not found" });
         return sendJson(res, 200, { ok: true });
       }
 
@@ -1685,42 +706,52 @@ const server = createServer(async (req, res) => {
             : [];
         }) : [];
         if (!message && images.length === 0) return sendJson(res, 400, { ok: false, error: "message or image is required" });
-        const result = await sessionService.prompt(typeof body.sessionId === "string" ? body.sessionId : undefined, {
+        const target = await sessionService.require(resolveSessionId(body.sessionId));
+        const clientMessageId = cleanClientId(body.clientMessageId);
+        const sourceClientId = clientIdFromRequest(req);
+        if (mockMode && clientMessageId && sourceClientId) {
+          const key = target.sessionFile || target.sessionId;
+          const pending = mockPromptCorrelations.get(key) || [];
+          pending.push({ clientMessageId, sourceClientId });
+          mockPromptCorrelations.set(key, pending);
+        }
+        const result = await sessionService.prompt(target.sessionId, {
           message,
           mode: body.mode === "followUp" ? "followUp" : "steer",
           images,
-          clientMessageId: cleanClientId(body.clientMessageId),
-          sourceClientId: clientIdFromRequest(req),
+          clientMessageId,
+          sourceClientId,
         });
         return sendJson(res, 202, { ok: true, ...result });
       }
 
       if (method === "POST" && url.pathname === "/api/session/retry") {
         const body = await readBody(req) as { sessionId?: unknown };
-        return sendJson(res, 202, { ok: true, ...await sessionService.retry(typeof body.sessionId === "string" ? body.sessionId : undefined) });
+        return sendJson(res, 202, { ok: true, ...await sessionService.retry(resolveSessionId(body.sessionId)) });
       }
 
       if (method === "POST" && url.pathname === "/api/abort") {
         const body = await readBody(req) as { sessionId?: unknown };
-        return sendJson(res, 202, { ok: true, ...await sessionService.abort(typeof body.sessionId === "string" ? body.sessionId : undefined) });
+        return sendJson(res, 202, { ok: true, ...await sessionService.abort(resolveSessionId(body.sessionId)) });
       }
 
       if (method === "POST" && url.pathname === "/api/compaction/abort") {
         const body = await readBody(req) as { sessionId?: unknown };
-        return sendJson(res, 202, { ok: true, ...await sessionService.abortCompaction(typeof body.sessionId === "string" ? body.sessionId : undefined) });
+        return sendJson(res, 202, { ok: true, ...await sessionService.abortCompaction(resolveSessionId(body.sessionId)) });
       }
 
       if (method === "POST" && url.pathname === "/api/session/name") {
         const body = await readBody(req) as { sessionId?: unknown; name?: unknown };
         const name = String(body.name || "").trim();
-        const state = await sessionService.rename(typeof body.sessionId === "string" ? body.sessionId : undefined, name);
+        const state = await decorateServiceState(await sessionService.rename(resolveSessionId(body.sessionId), name));
         return sendJson(res, 200, { ok: true, ...state });
       }
 
       if (method === "POST" && (url.pathname === "/api/new-chat" || url.pathname === "/api/sessions/new")) {
         const body = await readBody(req) as { cwd?: unknown; sessionId?: unknown };
-        const state = await sessionService.create(typeof body.sessionId === "string" ? body.sessionId : undefined, typeof body.cwd === "string" ? body.cwd : undefined);
-        noteViewerLeaseFromRequest(req, await sessionService.require(String(state.sessionId)));
+        const baseState = await sessionService.create(resolveSessionId(body.sessionId), typeof body.cwd === "string" ? body.cwd : undefined);
+        const state = await decorateServiceState(baseState);
+        noteViewerLeaseFromRequest(req, await sessionService.require(state.sessionId));
         broadcast({ type: "state_changed", ...state });
         return sendJson(res, 200, { ok: true, ...state });
       }
@@ -1730,9 +761,9 @@ const server = createServer(async (req, res) => {
         const cwd = String(body.cwd || "").trim();
         if (!cwd) return sendJson(res, 400, { ok: false, error: "cwd is required" });
         try {
-          const state = await sessionService.switchCwd(typeof body.sessionId === "string" ? body.sessionId : undefined, cwd);
-          const stateSession = state.sessionId ? await getOrCreateLiveSessionById(String(state.sessionId)) : undefined;
-          if (stateSession) noteViewerLeaseFromRequest(req, stateSession);
+          const baseState = await sessionService.switchCwd(resolveSessionId(body.sessionId), cwd);
+          const state = await decorateServiceState(baseState);
+          noteViewerLeaseFromRequest(req, await sessionService.require(state.sessionId));
           broadcast({ type: "state_changed", ...state });
           return sendJson(res, 200, { ok: true, ...state });
         } catch (error) {
@@ -1746,7 +777,7 @@ const server = createServer(async (req, res) => {
         const requestedId = typeof body.sessionId === "string" ? body.sessionId : typeof body.id === "string" ? body.id : "";
         if (!requestedId) return sendJson(res, 400, { ok: false, error: "sessionId is required" });
 
-        const state = await sessionService.open(requestedId, typeof body.cwd === "string" && body.cwd.trim() ? body.cwd : undefined);
+        const state = await decorateServiceState(await sessionService.open(requestedId, typeof body.cwd === "string" && body.cwd.trim() ? body.cwd : undefined));
         noteViewerLeaseFromRequest(req, await sessionService.require(requestedId), body.clientId);
         return sendJson(res, 200, { ok: true, ...state });
       }
@@ -1789,10 +820,16 @@ wss.on("connection", async (ws, req) => {
   const latestSeq = realtimeHub.attach(realtimeWs, lastSeq);
 
   const requestedSessionId = url.searchParams.get("sessionId") || session.sessionId;
-  const targetSession = requestedSessionId === session.sessionId ? session : await getOrCreateLiveSessionById(requestedSessionId);
+  let targetSession: PiWebSession | undefined;
+  try {
+    targetSession = await resolveWebSocketHelloSession(requestedSessionId, session, (id) => sessionService.find(id));
+  } catch {
+    realtimeWs.close(1011, "Could not open requested session");
+    return;
+  }
   const clientId = cleanClientId(url.searchParams.get("clientId") || "");
   if (clientId) {
-    acquireViewerLease(clientId, targetSession || session);
+    sessionService.acquireViewer((targetSession || session).sessionId, clientId);
     bindViewerSocket(clientId, realtimeWs);
   }
   const helloState = targetSession ? currentState(targetSession) : currentState();

--- a/server/session/dto.ts
+++ b/server/session/dto.ts
@@ -36,6 +36,21 @@ export interface BaseSessionStateDto {
   stats: SessionStatsDto;
 }
 
+/** Serializable message projection consumed by the browser message list. */
+export interface MessageDto {
+  entryId?: string;
+  role?: string;
+  text?: string;
+  toolCalls?: Array<{ id?: string; toolName: string; args: JsonValue; startedAt?: string }>;
+  toolCallId?: string;
+  toolName?: string;
+  toolArgs?: JsonValue;
+  isError?: boolean;
+  timestamp?: string;
+  raw?: JsonValue;
+  [key: string]: JsonValue | undefined;
+}
+
 export interface TreeNodeDto {
   id: string;
   parentId: string | null;
@@ -68,33 +83,78 @@ export interface SlashCommandDto {
   sourceInfo?: JsonValue;
 }
 
-export type NavigationResult = Record<string, unknown> & { finish(): void };
+export interface SessionInfoDto {
+  id: string;
+  path: string;
+  name?: string;
+  firstMessage?: string;
+  created: string;
+  modified: string;
+  messageCount: number;
+  cwd: string;
+  isCurrent: false;
+}
+
+export interface ModelsResultDto {
+  cwd: string;
+  current?: ModelDto;
+  thinkingLevel: string;
+  thinkingLevels: string[];
+  models: ModelDto[];
+}
+
+export interface DeleteSessionResultDto {
+  id: string;
+  disposition: "trashed" | "deleted";
+}
+
+export type SessionServiceEvent =
+  | { type: "pi"; sessionId: string; sessionFile: string; event: JsonValue; clientMessageId?: string; sourceClientId?: string }
+  | { type: "state"; state: BaseSessionStateDto; includeThinkingLevels?: boolean }
+  | { type: "stats"; sessionId: string; sessionFile: string; stats: SessionStatsDto }
+  | { type: "models"; sessionId: string; models: ModelDto[] }
+  | { type: "error"; sessionId?: string; sessionFile?: string; error: string; clientMessageId?: string }
+  | { type: "shutdown"; sessionId: string; sessionFile: string; sessionKey: string }
+  | { type: "runtime"; sessionId: string; sessionFile: string; activitySessionFile?: string; action: "ensure" | "clear" | "changed" | "completed" }
+  | { type: "wire"; value: JsonValue };
+
+/**
+ * Navigation has one serving-side finalizer. `finish` is intentionally not
+ * serializable: a remote runner returns the data first and its serving adapter
+ * finalizes only after writing that data to its own transport.
+ */
+export type NavigationResult = {
+  state: BaseSessionStateDto;
+  finish(): void;
+  [key: string]: unknown;
+};
 
 export interface SessionService {
-  defaultSessionId(): string;
-  state(sessionId?: string): Promise<Record<string, unknown>>;
-  stats(sessionId?: string): Promise<{ sessionId: string; stats: SessionStatsDto }>;
-  tree(sessionId?: string): Promise<ConversationTreeDto>;
-  messages(sessionId?: string): Promise<unknown[]>;
-  commands(sessionId?: string): Promise<SlashCommandDto[]>;
-  models(sessionId?: string): Promise<Record<string, unknown>>;
-  setModel(sessionId: string | undefined, provider: string, id: string, thinkingLevel?: string): Promise<Record<string, unknown>>;
-  executeShell(sessionId: string | undefined, command: string, excludeFromContext: boolean): Promise<Record<string, unknown>>;
-  executeCommand(sessionId: string | undefined, command: string): Promise<Record<string, unknown>>;
-  prompt(sessionId: string | undefined, input: { message: string; mode: string; images: Array<{ data: string; mimeType: string; name?: string }>; clientMessageId?: string; sourceClientId?: string }): Promise<{ sessionId: string }>;
-  retry(sessionId?: string): Promise<{ sessionId: string }>;
-  abort(sessionId?: string): Promise<{ sessionId: string }>;
-  abortCompaction(sessionId?: string): Promise<{ sessionId: string }>;
-  abortBranchSummary(sessionId?: string): Promise<{ sessionId: string }>;
-  rename(sessionId: string | undefined, name: string): Promise<Record<string, unknown>>;
-  navigate(sessionId: string | undefined, targetId: string, options: Record<string, unknown>): Promise<NavigationResult>;
-  invokeHeaderAction(sessionId: string | undefined, key: unknown): Promise<Record<string, unknown>>;
-  invokeGitTab(sessionId: string | undefined, input: Record<string, unknown>): Promise<Record<string, unknown>>;
-  list(extraCwds?: string[]): Promise<Array<{ id: string } & Record<string, unknown>>>;
-  create(sessionId?: string, cwd?: string): Promise<Record<string, unknown>>;
-  open(sessionId: string, cwd?: string): Promise<Record<string, unknown>>;
-  delete(sessionId: string, cwd?: string): Promise<unknown>;
-  switchCwd(sessionId: string | undefined, cwd: string): Promise<Record<string, unknown>>;
+  state(sessionId: string): Promise<BaseSessionStateDto>;
+  stats(sessionId: string): Promise<{ sessionId: string; stats: SessionStatsDto }>;
+  tree(sessionId: string): Promise<ConversationTreeDto>;
+  messages(sessionId: string): Promise<MessageDto[]>;
+  commands(sessionId: string): Promise<SlashCommandDto[]>;
+  models(sessionId: string): Promise<ModelsResultDto>;
+  setModel(sessionId: string, provider: string, id: string, thinkingLevel?: string): Promise<BaseSessionStateDto>;
+  executeShell(sessionId: string, command: string, excludeFromContext: boolean): Promise<Record<string, JsonValue | undefined>>;
+  executeCommand(sessionId: string, command: string): Promise<{ message: string; state: BaseSessionStateDto }>;
+  prompt(sessionId: string, input: { message: string; mode: string; images: Array<{ data: string; mimeType: string; name?: string }>; clientMessageId?: string; sourceClientId?: string }): Promise<{ sessionId: string }>;
+  retry(sessionId: string): Promise<{ sessionId: string }>;
+  abort(sessionId: string): Promise<{ sessionId: string }>;
+  abortCompaction(sessionId: string): Promise<{ sessionId: string }>;
+  abortBranchSummary(sessionId: string): Promise<{ sessionId: string }>;
+  rename(sessionId: string, name: string): Promise<BaseSessionStateDto>;
+  navigate(sessionId: string, targetId: string, options: Record<string, unknown>): Promise<NavigationResult>;
+  invokeHeaderAction(sessionId: string, key: unknown): Promise<Record<string, unknown>>;
+  invokeArtifactAction(sessionId: string, input: Record<string, unknown>): Promise<Record<string, unknown>>;
+  invokeGitTab(sessionId: string, input: Record<string, unknown>): Promise<Record<string, unknown>>;
+  list(extraCwds?: string[]): Promise<SessionInfoDto[]>;
+  create(previousSessionId: string | undefined, cwd?: string): Promise<BaseSessionStateDto>;
+  open(sessionId: string, cwd?: string): Promise<BaseSessionStateDto>;
+  delete(sessionId: string, cwd?: string): Promise<DeleteSessionResultDto>;
+  switchCwd(sessionId: string, cwd: string): Promise<BaseSessionStateDto>;
+  subscribe(listener: (event: SessionServiceEvent) => void): () => void;
 }
 
 export function jsonRoundTrip<T>(value: T): T {

--- a/server/session/hostEvents.ts
+++ b/server/session/hostEvents.ts
@@ -1,0 +1,158 @@
+import type { PiWebSession } from "../types.js";
+import { SessionActivity } from "./activity.js";
+import type { BaseSessionStateDto, MessageDto, SessionServiceEvent } from "./dto.js";
+
+export type HostSessionStateDecoration = {
+  runtimeStartedAt?: string;
+  runtimeLastActivityAt?: string;
+  runtime: ReturnType<SessionActivity["runtimeForPath"]>;
+  webFooters: unknown[];
+  webHeaderActions: unknown[];
+  webArtifactActions: unknown[];
+  webGitTabs: unknown[];
+};
+export type DecoratedSessionState = BaseSessionStateDto & HostSessionStateDecoration;
+export type WireSessionState = Omit<DecoratedSessionState, "thinkingLevels"> & { thinkingLevels?: string[] };
+
+type HostEventDependencies = {
+  sessionForId(sessionId: string): PiWebSession | undefined;
+  projectState(session: PiWebSession): BaseSessionStateDto;
+  webUiEntries(session: PiWebSession): Pick<HostSessionStateDecoration, "webFooters" | "webHeaderActions" | "webArtifactActions" | "webGitTabs">;
+  sessionActivity: SessionActivity;
+  broadcast(value: unknown): void;
+  markSessionUnreadCompleted(sessionId: string): void;
+};
+
+export function decorateHostSessionState(
+  baseState: BaseSessionStateDto,
+  targetSession: PiWebSession,
+  sessionActivity: SessionActivity,
+  webUiEntries: HostEventDependencies["webUiEntries"],
+  includeThinkingLevels = false,
+): WireSessionState {
+  const { thinkingLevels, ...base } = baseState;
+  const isRunning = Boolean(base.isStreaming || base.isRetrying || base.isCompacting);
+  return {
+    ...base,
+    runtimeStartedAt: typeof (targetSession as any).runtimeStartedAt === "string"
+      ? (targetSession as any).runtimeStartedAt
+      : sessionActivity.startedAtForPath(targetSession.sessionFile, isRunning),
+    runtimeLastActivityAt: typeof (targetSession as any).runtimeLastActivityAt === "string"
+      ? (targetSession as any).runtimeLastActivityAt
+      : sessionActivity.lastActivityAtForPath(targetSession.sessionFile, isRunning),
+    runtime: sessionActivity.runtimeForPath(targetSession.sessionFile),
+    ...webUiEntries(targetSession),
+    ...(includeThinkingLevels ? { thinkingLevels } : {}),
+  };
+}
+
+export function decorateHostMessages(messages: MessageDto[], sessionFile: string, sessionActivity: SessionActivity): MessageDto[] {
+  return messages.map((message) => {
+    const raw = message.raw;
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return message;
+    const content = sessionActivity.decorateMessageContent(raw.content, sessionFile);
+    if (content === raw.content) return message;
+    const decoratedToolCalls = Array.isArray(content)
+      ? content.filter((part: any) => part?.type === "toolCall") as Array<{ startedAt?: string }>
+      : [];
+    return {
+      ...message,
+      ...(message.toolCalls ? {
+        toolCalls: message.toolCalls.map((call, index) => {
+          const startedAt = decoratedToolCalls[index]?.startedAt;
+          return startedAt && !call.startedAt ? { ...call, startedAt } : call;
+        }),
+      } : {}),
+      raw: { ...raw, content },
+    } as MessageDto;
+  });
+}
+
+/** Synchronous serving-layer adapter from service events to browser wire events. */
+export function createHostSessionEventHandler(deps: HostEventDependencies) {
+  const decorate = (state: BaseSessionStateDto, target: PiWebSession, includeThinkingLevels = false) =>
+    decorateHostSessionState(state, target, deps.sessionActivity, deps.webUiEntries, includeThinkingLevels);
+
+  return (serviceEvent: SessionServiceEvent): void => {
+    switch (serviceEvent.type) {
+      case "pi": {
+        const target = deps.sessionForId(serviceEvent.sessionId);
+        const enriched = target
+          ? deps.sessionActivity.enrichEvent(target, serviceEvent.event)
+          : { event: serviceEvent.event, sessionId: serviceEvent.sessionId, sessionFile: serviceEvent.sessionFile };
+        deps.broadcast({
+          type: "pi_event",
+          sessionId: enriched.sessionId,
+          sessionFile: enriched.sessionFile,
+          event: enriched.event,
+          ...(serviceEvent.clientMessageId ? { clientMessageId: serviceEvent.clientMessageId } : {}),
+          ...(serviceEvent.sourceClientId ? { sourceClientId: serviceEvent.sourceClientId } : {}),
+        });
+        deps.broadcast({
+          type: "session_runtime_changed",
+          sessionId: enriched.sessionId,
+          sessionFile: enriched.sessionFile,
+          runtime: deps.sessionActivity.runtimeForEvent(enriched.sessionFile, serviceEvent.event),
+        });
+        return;
+      }
+      case "state": {
+        const target = deps.sessionForId(serviceEvent.state.sessionId);
+        if (target) deps.broadcast({ type: "state_changed", ...decorate(serviceEvent.state, target, Boolean(serviceEvent.includeThinkingLevels)) });
+        return;
+      }
+      case "stats":
+        deps.broadcast({ type: "session_stats_changed", sessionId: serviceEvent.sessionId, sessionFile: serviceEvent.sessionFile, stats: serviceEvent.stats });
+        return;
+      case "models":
+        deps.broadcast({ type: "models_updated", sessionId: serviceEvent.sessionId, models: serviceEvent.models });
+        return;
+      case "error":
+        deps.broadcast({ type: "server_error", ...(serviceEvent.sessionId ? { sessionId: serviceEvent.sessionId } : {}), ...(serviceEvent.sessionFile ? { sessionFile: serviceEvent.sessionFile } : {}), error: serviceEvent.error });
+        return;
+      case "runtime": {
+        const target = deps.sessionForId(serviceEvent.sessionId);
+        if (!target) return;
+        const activitySessionFile = serviceEvent.activitySessionFile || serviceEvent.sessionFile;
+        if (serviceEvent.action === "ensure") {
+          deps.sessionActivity.ensureStarted(target);
+          return;
+        }
+        if (serviceEvent.action === "clear") {
+          deps.sessionActivity.clearStarted(target, activitySessionFile);
+          return;
+        }
+        if (serviceEvent.action === "completed") {
+          const isRunning = Boolean(target.isStreaming || target.isCompacting);
+          if (deps.sessionActivity.hasStarted(activitySessionFile) && !isRunning) {
+            deps.sessionActivity.clearStarted(target, activitySessionFile);
+            deps.markSessionUnreadCompleted(serviceEvent.sessionId);
+          }
+        }
+        deps.broadcast({ type: "session_runtime_changed", sessionId: serviceEvent.sessionId, sessionFile: serviceEvent.sessionFile, runtime: deps.sessionActivity.runtimeForPath(serviceEvent.sessionFile) });
+        return;
+      }
+      case "shutdown":
+        deps.sessionActivity.clearSession(serviceEvent.sessionKey, { sessionFile: serviceEvent.sessionFile });
+        deps.broadcast({ type: "session_runtime_changed", sessionId: serviceEvent.sessionId, sessionFile: serviceEvent.sessionFile, runtime: deps.sessionActivity.runtimeForPath(serviceEvent.sessionFile) });
+        return;
+      case "wire": {
+        const value = serviceEvent.value as any;
+        if (value?.type === "state_changed" && typeof value.sessionId === "string") {
+          const target = deps.sessionForId(value.sessionId);
+          if (target) return deps.broadcast({ type: "state_changed", ...decorate(deps.projectState(target), target, true) });
+        }
+        deps.broadcast(value);
+      }
+    }
+  };
+}
+
+/** Unknown IDs may use the legacy current-session fallback; open failures must propagate. */
+export async function resolveWebSocketHelloSession(
+  requestedSessionId: string,
+  currentSession: PiWebSession,
+  findSession: (sessionId: string) => Promise<PiWebSession | undefined>,
+): Promise<PiWebSession | undefined> {
+  return requestedSessionId === currentSession.sessionId ? currentSession : findSession(requestedSessionId);
+}

--- a/server/session/service.ts
+++ b/server/session/service.ts
@@ -1,182 +1,1113 @@
-import type { PiWebSession } from "../types.js";
-import type { NavigationResult, SessionService, SlashCommandDto } from "./dto.js";
-import { conversationTreeForSession, getSessionSlashCommands, messageEntryRefs, sessionStats, simplifyMessage, simplifyModel } from "./projection.js";
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createAgentSession,
+  getAgentDir,
+  type ModelRuntime,
+  SessionManager,
+  type SessionStartEvent,
+} from "@earendil-works/pi-coding-agent";
+import { assertDirectory } from "../shared/fsList.js";
+import type { PiWebSession, PiWebSessionInfo } from "../types.js";
+import { createWebUiBridge } from "../extensions/webUi.js";
+import { ResilientResourceLoader } from "../extensions/resilientLoader.js";
+import type {
+  BaseSessionStateDto,
+  DeleteSessionResultDto,
+  JsonValue,
+  MessageDto,
+  NavigationResult,
+  SessionInfoDto,
+  SessionService,
+  SessionServiceEvent,
+  SlashCommandDto,
+} from "./dto.js";
+import {
+  conversationTreeForSession,
+  getSessionSlashCommands,
+  isAssistantAbortedMessage,
+  isAssistantFailureMessage,
+  isIncompleteToolResultMessage,
+  messageEntryRefs,
+  projectSessionState,
+  sessionStats,
+  simplifyMessage,
+  simplifyModel,
+} from "./projection.js";
 
 export class SessionServiceError extends Error {
   constructor(message: string, readonly status = 400) { super(message); }
 }
 
+export interface SessionDefaults {
+  model?: { provider: string; id: string };
+  thinkingLevel?: string;
+}
+
+export interface LocalSessionFactoryInput {
+  path?: string;
+  cwd: string;
+  sessionStartEvent?: SessionStartEvent;
+}
+
+export interface LocalSessionFactory {
+  create(input: LocalSessionFactoryInput): Promise<{ session: PiWebSession; modelFallbackMessage?: string }>;
+  list?(cwd: string): Promise<PiWebSessionInfo[]>;
+  remove?(id: string, path: string): Promise<"trashed" | "deleted">;
+  readonly isMock?: boolean;
+}
+
+/** Only box-external configuration is injected; lifecycle and operations live here. */
+export interface LocalSessionConfiguration {
+  defaultsFor(cwd: string): Promise<SessionDefaults>;
+  finalizeCreatedSession(sessionId: string): Promise<unknown>;
+}
+
 export interface LocalSessionServiceDependencies {
-  currentSessionId(): string;
+  modelRuntime: ModelRuntime;
+  sessionFactory?: LocalSessionFactory;
+  additionalExtensionPaths(cwd: string): string[];
+  sessionConfig: LocalSessionConfiguration;
   globalCwd(): string;
-  resolve(sessionId: string): Promise<PiWebSession | undefined>;
-  cwd(session: PiWebSession): string;
-  decorateState(session: PiWebSession): Record<string, unknown>;
-  decorateMessageContent(content: unknown, sessionFile: string): unknown;
-  availableModels(session: PiWebSession): unknown[];
-  webCommands: SlashCommandDto[];
-  list(extraCwds: string[]): Promise<Array<{ id: string } & Record<string, unknown>>>;
-  create(cwd?: string, previousSessionFile?: string): Promise<PiWebSession>;
-  open(sessionId: string, cwd?: string): Promise<PiWebSession>;
-  delete(sessionId: string, cwd?: string): Promise<unknown>;
-  switchCwd(session: PiWebSession, cwd: string): Promise<Record<string, unknown>>;
-  executeCommand(command: string, session: PiWebSession): Promise<{ message: string; state: Record<string, unknown> }>;
-  prompt(session: PiWebSession, input: { message: string; mode: string; images: Array<{ data: string; mimeType: string; name?: string }>; clientMessageId?: string; sourceClientId?: string }): Promise<void>;
-  retry(session: PiWebSession): Promise<void>;
-  navigate(session: PiWebSession, targetId: string, options: Record<string, unknown>): Promise<NavigationResult>;
-  invokeHeaderAction(session: PiWebSession, key: unknown): Promise<Record<string, unknown>>;
-  invokeArtifactAction(session: PiWebSession, input: Record<string, unknown>): Promise<Record<string, unknown>>;
-  invokeGitTab(session: PiWebSession, input: Record<string, unknown>): Promise<Record<string, unknown>>;
-  reportError(session: PiWebSession, error: unknown): void;
+  clientCount(): number;
+}
+
+type LiveSessionEntry = {
+  session: PiWebSession;
+  unsubscribe?: () => void;
+  viewerClientIds: Set<string>;
+  workLeases: number;
+  disposeTimer?: ReturnType<typeof setTimeout>;
+  disposing?: boolean;
+};
+
+type ViewerLease = {
+  sessionKey: string;
+  sockets: Set<symbol>;
+  releaseTimer?: ReturnType<typeof setTimeout>;
+};
+
+type RetrySessionTarget =
+  | { kind: "failure"; messages: any[]; index: number; message: any }
+  | { kind: "aborted"; messages: any[]; index: number; message: any }
+  | { kind: "toolResult"; messages: any[]; index: number; message: any };
+
+type PendingPromptCorrelation = {
+  clientMessageId: string;
+  sourceClientId: string;
+  createdAt: number;
+};
+
+const webSlashCommands: SlashCommandDto[] = [
+  { name: "help", description: "Show slash command help", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+  { name: "commands", description: "List available web, extension, prompt, and skill commands", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+  { name: "reload", description: "Reload pi resources, extensions, skills, prompts, and models", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+  { name: "model", description: "List models or switch with /model <provider/model-id>", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+  { name: "models", description: "List available models", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+  { name: "thinking", description: "Show or set reasoning level", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+  { name: "new", description: "Start a new session", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+  { name: "clear", description: "Release this session to history and start fresh in the same tab", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+  { name: "compact", description: "Compact conversation context; optional instructions after the command", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+  { name: "abort", description: "Stop the current response", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+  { name: "stop", description: "Stop the current response", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+  { name: "logout", description: "Clear the web UI token in this browser", source: "web", sourceInfo: { path: "<pi-web>", source: "pi-web", scope: "temporary", origin: "top-level" } },
+];
+
+const imageExtensions: Record<string, string> = {
+  "image/gif": ".gif",
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+};
+
+const execFileAsync = promisify(execFile);
+
+function envMs(name: string, fallback: number) {
+  const raw = Number(process.env[name] || fallback);
+  return Number.isFinite(raw) && raw >= 0 ? raw : fallback;
+}
+
+function sessionPathKey(value: Pick<PiWebSession, "sessionFile" | "sessionId">) {
+  return String(value.sessionFile || value.sessionId || "");
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function jsonSafe<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function hasUserMessages(value: PiWebSession) {
+  return value.messages.some((message: any) => message?.role === "user");
 }
 
 export class LocalSessionService implements SessionService {
-  constructor(private readonly deps: LocalSessionServiceDependencies) {}
+  private readonly listeners = new Set<(event: SessionServiceEvent) => void>();
+  private readonly liveSessions = new Map<string, LiveSessionEntry>();
+  private readonly liveById = new Map<string, PiWebSession>();
+  private readonly sessionLocations = new Map<string, { path: string; cwd: string }>();
+  private readonly openingById = new Map<string, Promise<PiWebSession | undefined>>();
+  private readonly sessionListRequests = new Map<string, Promise<SessionInfoDto[]>>();
+  private readonly viewerLeases = new Map<string, ViewerLease>();
+  private readonly viewerConnections = new Map<symbol, string>();
+  private readonly extensionLoaders = new WeakMap<object, ResilientResourceLoader>();
+  private readonly blockedModelIds = new Set<string>();
+  private readonly pendingPromptCorrelations = new Map<string, PendingPromptCorrelation[]>();
+  private readonly knownSessionCwds = new Set<string>();
+  private readonly protectedSessionIds = new Set<string>();
+  private readonly noSession = process.env.PI_WEB_NO_SESSION === "1";
+  private readonly idleGraceMs = envMs("PI_WEB_SESSION_IDLE_GRACE_MS", 24 * 60 * 60 * 1000);
+  private readonly viewerGraceMs = envMs("PI_WEB_VIEWER_LEASE_GRACE_MS", Math.min(30_000, this.idleGraceMs));
+  private readonly webUiBridge;
 
-  defaultSessionId(): string { return this.deps.currentSessionId(); }
+  constructor(private readonly deps: LocalSessionServiceDependencies) {
+    this.knownSessionCwds.add(resolve(deps.globalCwd()));
+    this.webUiBridge = createWebUiBridge({
+      emit: (value) => this.emit({ type: "wire", value: value as JsonValue }),
+      clientCount: deps.clientCount,
+      acquireWorkLease: (session) => this.acquireWorkLease(session),
+      createNewSession: (cwd, previousSessionFile) => this.createNewLiveSession(cwd, previousSessionFile),
+      sessionCwd: (session) => this.sessionCwd(session),
+      state: (session) => this.projectState(session) as unknown as Record<string, unknown>,
+    });
+  }
+
+  subscribe(listener: (event: SessionServiceEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /**
+   * The runner boundary intentionally normalizes values through JSON and
+   * isolates listeners so one serving adapter cannot block the others.
+   */
+  private emit(event: SessionServiceEvent) {
+    const serializableEvent = jsonSafe(event);
+    for (const listener of this.listeners) {
+      try { listener(serializableEvent); }
+      catch (error) { console.warn("Session service event listener failed:", error); }
+    }
+  }
+
+  async initialize(path?: string): Promise<PiWebSession> {
+    const created = await this.makeAgentSession(path);
+    if (created.modelFallbackMessage) console.warn(created.modelFallbackMessage);
+    const value = this.registerLiveSession(created.session);
+    this.setCurrentSession(value);
+    return value;
+  }
+
+  setCurrentSession(value: PiWebSession) {
+    this.protectedSessionIds.clear();
+    this.protectedSessionIds.add(value.sessionId);
+    this.registerLiveSession(value);
+  }
+
+  async resetWith(value: PiWebSession) {
+    await this.disposeAll("reset");
+    this.setCurrentSession(value);
+  }
+
+  async disposeAll(reason: "reset" | "idle" = "reset") {
+    await Promise.all(Array.from(this.liveSessions.keys()).map((key) => this.disposeLiveSession(key, reason, true)));
+  }
+
+  sessionForPath(path: string) { return this.liveSessions.get(path)?.session; }
+  sessionForId(id: string) { return this.liveById.get(id); }
+  cwdForSession(value: PiWebSession) { return this.sessionCwd(value); }
+  async cwdForSessionId(id: string) {
+    const live = this.liveById.get(id);
+    if (live) return this.sessionCwd(live);
+    const info = await this.findSessionInfoById(id);
+    if (!info) throw new SessionServiceError("Session not found", 404);
+    return info.cwd || this.deps.globalCwd();
+  }
+  knownCwds() { return new Set([resolve(this.deps.globalCwd()), ...this.knownSessionCwds]); }
+  webUiEntries(value: PiWebSession) { return this.webUiBridge.entries(value); }
+  projectState(value: PiWebSession): BaseSessionStateDto { return jsonSafe(projectSessionState(value, this.sessionCwd(value))); }
+
+  private currentSession() {
+    for (const id of this.protectedSessionIds) {
+      const value = this.liveById.get(id);
+      if (value) return value;
+    }
+    return undefined;
+  }
+
+  async find(sessionId: string): Promise<PiWebSession | undefined> {
+    if (!sessionId) return undefined;
+    return this.getOrCreateLiveSessionById(sessionId);
+  }
 
   async require(sessionId?: string): Promise<PiWebSession> {
-    const id = sessionId || this.defaultSessionId();
-    const session = await this.deps.resolve(id);
-    if (!session) throw new SessionServiceError("Session not found", 404);
-    return session;
+    const value = sessionId ? await this.find(sessionId) : this.currentSession();
+    if (!value) throw new SessionServiceError("Session not found", 404);
+    return value;
   }
 
-  async state(sessionId?: string) {
-    return this.deps.decorateState(await this.require(sessionId));
+  async state(sessionId: string) { return this.projectState(await this.require(sessionId)); }
+
+  async stats(sessionId: string) {
+    const value = await this.require(sessionId);
+    return jsonSafe({ sessionId: value.sessionId, stats: sessionStats(value) });
   }
 
-  async stats(sessionId?: string) {
-    const session = await this.require(sessionId);
-    return { sessionId: session.sessionId, stats: sessionStats(session) };
+  async tree(sessionId: string) {
+    const value = await this.require(sessionId);
+    try { return jsonSafe(conversationTreeForSession(value)); }
+    catch (error) { throw new SessionServiceError(errorMessage(error), 400); }
   }
 
-  async tree(sessionId?: string) {
-    const session = await this.require(sessionId);
-    try { return conversationTreeForSession(session); }
-    catch (error) { throw new SessionServiceError(error instanceof Error ? error.message : String(error), 400); }
-  }
-
-  async messages(sessionId?: string) {
-    const session = await this.require(sessionId);
-    const messages = session.messages;
+  async messages(sessionId: string): Promise<MessageDto[]> {
+    const value = await this.require(sessionId);
     const toolCallArgs = new Map<string, Record<string, unknown>>();
-    for (const message of messages as any[]) {
+    for (const message of value.messages as any[]) {
       if (message?.role !== "assistant" || !Array.isArray(message.content)) continue;
       for (const part of message.content) {
         if (part?.type === "toolCall" && part.id) toolCallArgs.set(part.id, part.arguments || {});
       }
     }
-    const refs = messageEntryRefs(session);
-    return messages.map((message, index) => simplifyMessage(message, {
+    const refs = messageEntryRefs(value);
+    return jsonSafe(value.messages.map((message, index) => simplifyMessage(message, {
       toolCallArgs,
-      decorateContent: (content) => this.deps.decorateMessageContent(content, session.sessionFile),
       entryId: refs[index]?.entryId,
-    }));
+    }) as MessageDto));
   }
 
-  async commands(sessionId?: string) {
-    const session = await this.require(sessionId);
-    return [...this.deps.webCommands, ...getSessionSlashCommands(session)];
+  async commands(sessionId: string) {
+    return jsonSafe([...webSlashCommands, ...getSessionSlashCommands(await this.require(sessionId))]);
   }
 
-  async models(sessionId?: string) {
-    const session = await this.require(sessionId);
-    return {
-      cwd: this.deps.cwd(session),
-      current: simplifyModel(session.model),
-      thinkingLevel: session.thinkingLevel,
-      thinkingLevels: session.getAvailableThinkingLevels(),
-      models: this.deps.availableModels(session).map(simplifyModel),
-    };
+  private copilotAllowedIds(value: PiWebSession): Set<string> | null {
+    for (let index = value.messages.length - 1; index >= 0; index--) {
+      const message = value.messages[index] as any;
+      const error: string = message?.errorMessage || message?.message?.errorMessage || "";
+      if (!error.includes("model_not_available_for_integrator")) continue;
+      const match = error.match(/Available models: \[([^\]]+)\]/);
+      if (match) return new Set(match[1].split(/\s+/).map((id: string) => id.trim()).filter(Boolean));
+    }
+    return null;
   }
 
-  async setModel(sessionId: string | undefined, provider: string, id: string, thinkingLevel?: string) {
-    const session = await this.require(sessionId);
-    const model = session.modelRuntime.getModel(provider, id);
+  private availableModels(value: PiWebSession) {
+    const allowed = this.copilotAllowedIds(value);
+    return value.modelRuntime.getAvailableSnapshot().filter((model) => !this.blockedModelIds.has(model.id) && (!allowed || allowed.has(model.id)));
+  }
+
+  async models(sessionId: string) {
+    const value = await this.require(sessionId);
+    return jsonSafe({
+      cwd: this.sessionCwd(value),
+      current: simplifyModel(value.model),
+      thinkingLevel: value.thinkingLevel,
+      thinkingLevels: value.getAvailableThinkingLevels(),
+      models: this.availableModels(value).map(simplifyModel).filter((model) => model !== undefined),
+    });
+  }
+
+  async setModel(sessionId: string, provider: string, id: string, thinkingLevel?: string) {
+    const value = await this.require(sessionId);
+    const model = value.modelRuntime.getModel(provider, id);
     if (!model) throw new SessionServiceError("Model not found", 404);
-    await session.setModel(model);
-    if (thinkingLevel !== undefined) session.setThinkingLevel(thinkingLevel);
-    return this.deps.decorateState(session);
+    await value.setModel(model);
+    if (thinkingLevel !== undefined) value.setThinkingLevel(thinkingLevel);
+    return this.projectState(value);
   }
 
-  async executeShell(sessionId: string | undefined, command: string, excludeFromContext: boolean) {
-    const session = await this.require(sessionId);
-    if (!session.executeBash) throw new SessionServiceError("Bash execution is not available in this session.");
-    return { command, cwd: this.deps.cwd(session), ...await session.executeBash(command, undefined, { excludeFromContext }), excludeFromContext };
+  async executeShell(sessionId: string, command: string, excludeFromContext: boolean) {
+    const value = await this.require(sessionId);
+    if (!value.executeBash) throw new SessionServiceError("Bash execution is not available in this session.");
+    return jsonSafe({ command, cwd: this.sessionCwd(value), ...await value.executeBash(command, undefined, { excludeFromContext }), excludeFromContext });
   }
 
-  async executeCommand(sessionId: string | undefined, command: string) {
-    return this.deps.executeCommand(command, await this.require(sessionId));
+  async executeCommand(sessionId: string, command: string) {
+    return this.executeSlashCommand(command, await this.require(sessionId));
   }
 
-  async prompt(sessionId: string | undefined, input: { message: string; mode: string; images: Array<{ data: string; mimeType: string; name?: string }>; clientMessageId?: string; sourceClientId?: string }) {
-    const session = await this.require(sessionId);
-    await this.deps.prompt(session, input);
-    return { sessionId: session.sessionId };
+  async prompt(sessionId: string, input: { message: string; mode: string; images: Array<{ data: string; mimeType: string; name?: string }>; clientMessageId?: string; sourceClientId?: string }) {
+    const value = await this.require(sessionId);
+    await this.startSessionPrompt(value, input);
+    return { sessionId: value.sessionId };
   }
 
-  async retry(sessionId?: string) {
-    const session = await this.require(sessionId);
-    await this.deps.retry(session);
-    return { sessionId: session.sessionId };
+  async retry(sessionId: string) {
+    const value = await this.require(sessionId);
+    await this.startSessionRetry(value);
+    return { sessionId: value.sessionId };
   }
 
-  async abort(sessionId?: string) {
-    const session = await this.require(sessionId);
-    void session.abort().catch((error) => this.deps.reportError(session, error));
-    return { sessionId: session.sessionId };
+  async abort(sessionId: string) {
+    const value = await this.require(sessionId);
+    void value.abort().catch((error) => this.emitError(value, error));
+    return { sessionId: value.sessionId };
   }
 
-  async abortCompaction(sessionId?: string) {
-    const session = await this.require(sessionId);
-    if (!session.abortCompaction) throw new SessionServiceError("Compaction cancellation is not available");
-    session.abortCompaction();
-    return { sessionId: session.sessionId };
+  async abortCompaction(sessionId: string) {
+    const value = await this.require(sessionId);
+    if (!value.abortCompaction) throw new SessionServiceError("Compaction cancellation is not available");
+    value.abortCompaction();
+    return { sessionId: value.sessionId };
   }
 
-  async abortBranchSummary(sessionId?: string) {
-    const session = await this.require(sessionId);
-    session.abortBranchSummary?.();
-    return { sessionId: session.sessionId };
+  async abortBranchSummary(sessionId: string) {
+    const value = await this.require(sessionId);
+    value.abortBranchSummary?.();
+    return { sessionId: value.sessionId };
   }
 
-  async rename(sessionId: string | undefined, name: string) {
-    const session = await this.require(sessionId);
-    if (!session.setSessionName) throw new SessionServiceError("Renaming sessions is not available");
-    session.setSessionName(name);
-    return this.deps.decorateState(session);
+  async rename(sessionId: string, name: string) {
+    const value = await this.require(sessionId);
+    if (!value.setSessionName) throw new SessionServiceError("Renaming sessions is not available");
+    value.setSessionName(name);
+    return this.projectState(value);
   }
 
-  async navigate(sessionId: string | undefined, targetId: string, options: Record<string, unknown>) {
-    return this.deps.navigate(await this.require(sessionId), targetId, options);
+  async navigate(sessionId: string, targetId: string, options: Record<string, unknown>): Promise<NavigationResult> {
+    const value = await this.require(sessionId);
+    if (value.isStreaming) throw new SessionServiceError("Wait for the current response to finish before navigating the tree", 409);
+    if (value.isCompacting) throw new SessionServiceError("Wait for the current compaction to finish before navigating the tree", 409);
+    if (!value.navigateTree) throw new SessionServiceError("Tree navigation is not available");
+    const releaseWorkLease = this.acquireWorkLease(value);
+    let finished = false;
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      releaseWorkLease();
+      this.emitRuntime(value, "changed");
+    };
+    try {
+      const navigation = value.navigateTree(targetId, options as any);
+      this.emitRuntime(value, "changed");
+      const result = await navigation;
+      const state = this.projectState(value);
+      this.emit({ type: "state", state, includeThinkingLevels: true });
+      return { ...jsonSafe(result as Record<string, JsonValue>), leafId: value.sessionManager.getLeafId?.() || null, state, finish };
+    } catch (error) {
+      finish();
+      throw error;
+    }
   }
 
-  async invokeHeaderAction(sessionId: string | undefined, key: unknown) {
-    return this.deps.invokeHeaderAction(await this.require(sessionId), key);
+  invokeHeaderAction(sessionId: string | undefined, key: unknown) {
+    return this.require(sessionId).then((value) => this.webUiBridge.invokeHeaderAction(value, key));
   }
 
-  async invokeArtifactAction(sessionId: string | undefined, input: Record<string, unknown>) {
-    return this.deps.invokeArtifactAction(await this.require(sessionId), input);
+  invokeArtifactAction(sessionId: string | undefined, input: Record<string, unknown>) {
+    return this.require(sessionId).then((value) => this.webUiBridge.invokeArtifactAction(value, input));
   }
 
-  async invokeGitTab(sessionId: string | undefined, input: Record<string, unknown>) {
-    return this.deps.invokeGitTab(await this.require(sessionId), input);
+  invokeGitTab(sessionId: string | undefined, input: Record<string, unknown>) {
+    return this.require(sessionId).then((value) => this.webUiBridge.invokeGitTab(value, input));
   }
 
-  list(extraCwds: string[] = []) { return this.deps.list(extraCwds); }
+  respondExtensionUi(id: string, response: Record<string, unknown>) { return this.webUiBridge.respond(id, response); }
 
-  async create(sessionId?: string, cwd?: string) {
-    const previous = await this.deps.resolve(sessionId || this.deps.currentSessionId());
-    const created = await this.deps.create(cwd || (previous ? this.deps.cwd(previous) : this.deps.globalCwd()), previous?.sessionFile);
-    return this.deps.decorateState(created);
+  extensionStatus(sessionId: string) {
+    const value = this.openExtensionSession(sessionId);
+    const loader = this.extensionLoaders.get(value);
+    if (!loader) throw new SessionServiceError("Extension status is not available for this session.", 404);
+    return loader.getStatus();
+  }
+
+  async reloadExtensions(sessionId: string) {
+    const value = this.openExtensionSession(sessionId);
+    if (value.isStreaming) throw new SessionServiceError("Wait for the current response to finish before retrying extensions.", 409);
+    if (value.isCompacting) throw new SessionServiceError("Wait for compaction to finish before retrying extensions.", 409);
+    const loader = this.extensionLoaders.get(value);
+    if (!loader || typeof value.reload !== "function") throw new SessionServiceError("Extension reload is not available for this session.", 404);
+    await value.reload();
+    const status = loader.getStatus();
+    this.emit({ type: "wire", value: { type: "extensions_reloaded", sessionId: value.sessionId, status } as JsonValue });
+    return status;
+  }
+
+  async list(extraCwds: string[] = []): Promise<SessionInfoDto[]> {
+    if (this.noSession) return [];
+    const cwds = this.knownCwds();
+    for (const cwd of extraCwds) if (typeof cwd === "string" && cwd.trim()) cwds.add(resolve(cwd));
+    const orderedCwds = Array.from(cwds).sort();
+    const key = orderedCwds.join("\n");
+    const pending = this.sessionListRequests.get(key);
+    if (pending) return pending;
+    const request = (async () => {
+      const groups = await Promise.all(orderedCwds.map(async (cwd) => {
+        try {
+          const infos = this.deps.sessionFactory?.list
+            ? await this.deps.sessionFactory.list(cwd)
+            : await SessionManager.list(cwd);
+          return infos.map((info) => this.simplifySessionInfo(info, cwd));
+        } catch { return []; }
+      }));
+      return groups.flat().sort((a, b) => Date.parse(b.modified) - Date.parse(a.modified));
+    })();
+    this.sessionListRequests.set(key, request);
+    try { return await request; }
+    finally { this.sessionListRequests.delete(key); }
+  }
+
+  async create(sessionId: string | undefined, cwd?: string) {
+    const previous = sessionId ? await this.getOrCreateLiveSessionById(sessionId) : this.currentSession();
+    const created = await this.createNewLiveSession(cwd || (previous ? this.sessionCwd(previous) : this.deps.globalCwd()), previous?.sessionFile);
+    return this.projectState(created);
   }
 
   async open(sessionId: string, cwd?: string) {
-    try { return this.deps.decorateState(await this.deps.open(sessionId, cwd)); }
-    catch (error) { throw new SessionServiceError(error instanceof Error ? error.message : String(error), 404); }
+    try {
+      const value = await this.getOrCreateLiveSessionById(sessionId, cwd);
+      if (!value) throw new Error("Session not found");
+      return this.projectState(value);
+    } catch (error) { throw new SessionServiceError(errorMessage(error), 404); }
   }
 
-  delete(sessionId: string, cwd?: string) { return this.deps.delete(sessionId, cwd); }
-  async switchCwd(sessionId: string | undefined, cwd: string) { return this.deps.switchCwd(await this.require(sessionId), cwd); }
+  async delete(sessionId: string, cwd?: string): Promise<DeleteSessionResultDto> {
+    if (this.noSession) throw new Error("Sessions are disabled.");
+    const info = await this.findSessionInfoById(sessionId, cwd);
+    if (!info) throw new SessionServiceError("Session not found", 404);
+    const live = this.liveSessions.get(info.path);
+    if (live?.session.isStreaming || live?.session.isCompacting) throw new SessionServiceError("Wait for the session to finish before deleting it.", 409);
+    if (live) await this.disposeLiveSession(info.path, "delete", true);
+    const disposition = this.deps.sessionFactory?.remove
+      ? await this.deps.sessionFactory.remove(sessionId, info.path)
+      : await this.trashOrRemoveSessionFile(info.path);
+    return { id: sessionId, disposition };
+  }
+
+  async switchCwd(sessionId: string, cwd: string) {
+    const value = await this.require(sessionId);
+    if (value.isStreaming) throw new Error("Wait for the current response to finish before changing the working directory.");
+    if (value.isCompacting) throw new Error("Wait for compaction to finish before changing the working directory.");
+    if (hasUserMessages(value)) throw new Error("Working directory can only be changed before the first message.");
+    return this.projectState(await this.createNewLiveSession(cwd, value.sessionFile));
+  }
+
+  acquireViewer(sessionId: string, clientId: string) {
+    const value = this.liveById.get(sessionId);
+    if (!clientId || !value) return;
+    const key = sessionPathKey(value);
+    const entry = this.liveSessions.get(key);
+    if (!entry) return;
+    let lease = this.viewerLeases.get(clientId);
+    this.clearTimer(lease?.releaseTimer);
+    if (!lease) {
+      lease = { sessionKey: key, sockets: new Set() };
+      this.viewerLeases.set(clientId, lease);
+    } else if (lease.sessionKey !== key) {
+      const previousKey = lease.sessionKey;
+      this.liveSessions.get(previousKey)?.viewerClientIds.delete(clientId);
+      this.scheduleLiveSessionCleanup(previousKey);
+      lease.sessionKey = key;
+    }
+    entry.viewerClientIds.add(clientId);
+    this.cancelLiveSessionCleanup(entry);
+    if (lease.sockets.size === 0) this.scheduleViewerLeaseRelease(clientId);
+  }
+
+  connectViewer(clientId: string) {
+    const lease = this.viewerLeases.get(clientId);
+    if (!lease) return undefined;
+    this.clearTimer(lease.releaseTimer);
+    lease.releaseTimer = undefined;
+    const connection = Symbol(clientId);
+    lease.sockets.add(connection);
+    this.viewerConnections.set(connection, clientId);
+    return connection;
+  }
+
+  disconnectViewer(connection: symbol) {
+    const clientId = this.viewerConnections.get(connection);
+    if (!clientId) return;
+    this.viewerConnections.delete(connection);
+    const lease = this.viewerLeases.get(clientId);
+    if (!lease || !lease.sockets.delete(connection) || lease.sockets.size > 0) return;
+    this.releaseViewer(clientId);
+  }
+
+  releaseViewer(clientId: string) {
+    const lease = this.viewerLeases.get(clientId);
+    if (!lease) return;
+    this.clearTimer(lease.releaseTimer);
+    this.viewerLeases.delete(clientId);
+    for (const connection of lease.sockets) this.viewerConnections.delete(connection);
+    lease.sockets.clear();
+    const entry = this.liveSessions.get(lease.sessionKey);
+    if (entry) {
+      entry.viewerClientIds.delete(clientId);
+      this.scheduleLiveSessionCleanup(lease.sessionKey);
+    }
+  }
+
+  lifecycleSnapshot() {
+    return {
+      liveSessions: Array.from(this.liveSessions.values()).map((entry) => ({
+        sessionId: entry.session.sessionId,
+        sessionFile: entry.session.sessionFile,
+        viewerLeases: entry.viewerClientIds.size,
+        workLeases: entry.workLeases,
+        hasDisposeTimer: Boolean(entry.disposeTimer),
+        isStreaming: Boolean(entry.session.isStreaming),
+        isCompacting: Boolean(entry.session.isCompacting),
+      })),
+      viewerLeases: Array.from(this.viewerLeases.entries()).map(([clientId, lease]) => ({
+        clientId,
+        sessionKey: lease.sessionKey,
+        sockets: lease.sockets.size,
+        hasReleaseTimer: Boolean(lease.releaseTimer),
+      })),
+    };
+  }
+
+  private sessionCwd(value: PiWebSession | any) {
+    return String(value?.sessionManager?.getCwd?.() || value?.cwd || this.deps.globalCwd());
+  }
+
+  private async ensureStorage(cwd: string) {
+    const webDir = join(cwd, ".pi", "web");
+    await mkdir(webDir, { recursive: true });
+    const ignoreFile = join(webDir, ".gitignore");
+    if (!existsSync(ignoreFile)) await writeFile(ignoreFile, "*\n");
+  }
+
+  private async makeAgentSession(path?: string, sessionStartEvent?: SessionStartEvent, cwd = this.deps.globalCwd()) {
+    const targetCwd = await assertDirectory(cwd, this.deps.globalCwd());
+    if (this.deps.sessionFactory) {
+      const result = await this.deps.sessionFactory.create({ path, cwd: targetCwd, sessionStartEvent });
+      await this.webUiBridge.bind(result.session);
+      return result;
+    }
+
+    const manager = this.noSession
+      ? SessionManager.inMemory(targetCwd)
+      : path ? SessionManager.open(path) : SessionManager.create(targetCwd);
+    if (!path && !this.noSession && sessionStartEvent?.reason === "new") manager.newSession();
+    const resolvedCwd = this.sessionCwd({ sessionManager: manager });
+    this.knownSessionCwds.add(resolve(resolvedCwd));
+    await this.ensureStorage(resolvedCwd);
+    const contextPath = fileURLToPath(new URL("../../contexts/web-ui.md", import.meta.url));
+    const webUiContext = existsSync(contextPath) ? readFileSync(contextPath, "utf8") : "";
+    const loader = new ResilientResourceLoader({
+      loadTimeoutMs: envMs("PI_WEB_EXTENSION_LOAD_TIMEOUT_MS", 8_000),
+      fetchTimeoutMs: envMs("PI_WEB_EXTENSION_FETCH_TIMEOUT_MS", 3_000),
+      loaderOptions: {
+        cwd: resolvedCwd,
+        agentDir: getAgentDir(),
+        additionalExtensionPaths: this.deps.additionalExtensionPaths(resolvedCwd),
+        appendSystemPromptOverride: (base) => [...base, webUiContext].filter(Boolean),
+      },
+    });
+    await loader.reload();
+    const result = await createAgentSession({
+      cwd: resolvedCwd,
+      sessionManager: manager,
+      modelRuntime: this.deps.modelRuntime,
+      resourceLoader: loader,
+      sessionStartEvent,
+    });
+    this.extensionLoaders.set(result.session, loader);
+    await this.webUiBridge.bind(result.session);
+    return { session: result.session as unknown as PiWebSession, modelFallbackMessage: result.modelFallbackMessage };
+  }
+
+  private async createNewLiveSession(cwd?: string, previousSessionFile?: string) {
+    const targetCwd = cwd ? await assertDirectory(cwd, this.deps.globalCwd()) : resolve(this.deps.globalCwd());
+    this.knownSessionCwds.add(targetCwd);
+    await this.ensureStorage(targetCwd);
+    const created = await this.makeAgentSession(undefined, { type: "session_start", reason: "new", previousSessionFile }, targetCwd);
+    if (created.modelFallbackMessage) console.warn(created.modelFallbackMessage);
+    const value = created.session;
+    if (this.deps.sessionFactory?.isMock) {
+      value.sessionManager.newSession();
+      value.agent.state.messages = value.sessionManager.buildSessionContext().messages;
+    }
+    await this.applyDefaults(value);
+    this.registerLiveSession(value);
+    await this.deps.sessionConfig.finalizeCreatedSession(value.sessionId);
+    return value;
+  }
+
+  private async applyDefaults(value: PiWebSession) {
+    const defaults = await this.deps.sessionConfig.defaultsFor(this.sessionCwd(value));
+    if (defaults.model) {
+      const model = value.modelRuntime.getModel(defaults.model.provider, defaults.model.id);
+      if (model) await value.setModel(model);
+    }
+    if (defaults.thinkingLevel && value.getAvailableThinkingLevels().includes(defaults.thinkingLevel)) value.setThinkingLevel(defaults.thinkingLevel);
+  }
+
+  private registerLiveSession(value: PiWebSession) {
+    const key = sessionPathKey(value);
+    if (!key || this.liveSessions.get(key)?.session === value) return value;
+    const unsubscribe = value.subscribe?.((event) => this.handlePiEvent(value, event));
+    this.liveSessions.set(key, { session: value, unsubscribe, viewerClientIds: new Set(), workLeases: 0 });
+    this.liveById.set(value.sessionId, value);
+    if (value.sessionFile) this.sessionLocations.set(value.sessionId, { path: resolve(value.sessionFile), cwd: resolve(this.sessionCwd(value)) });
+    queueMicrotask(() => this.scheduleLiveSessionCleanup(key));
+    return value;
+  }
+
+  private handlePiEvent(value: PiWebSession, event: unknown) {
+    const e = event as any;
+    const sessionId = value.sessionId;
+    const sessionFile = value.sessionFile;
+    const correlation = this.takePromptCorrelation(sessionPathKey(value), e);
+    this.emit({
+      type: "pi",
+      sessionId,
+      sessionFile,
+      event: event as JsonValue,
+      ...(correlation ? { clientMessageId: correlation.clientMessageId, sourceClientId: correlation.sourceClientId } : {}),
+    });
+    if (e?.type === "session_info_changed") this.emit({ type: "state", state: this.projectState(value) });
+    if (e?.type === "message_end" || e?.type === "agent_end" || e?.type === "compaction_end") {
+      this.emit({ type: "stats", sessionId, sessionFile, stats: sessionStats(value) });
+    }
+    if (e?.type === "message_end" || e?.type === "turn_end") {
+      const message = e?.message ?? e?.toolResults?.[0];
+      const error: string = message?.errorMessage || message?.message?.errorMessage || "";
+      const modelId: string = message?.model || message?.message?.model || "";
+      if (modelId && (error.includes("model_not_supported") || error.includes("model_not_available")) && !this.blockedModelIds.has(modelId)) {
+        this.blockedModelIds.add(modelId);
+        this.emit({ type: "models", sessionId, models: this.availableModels(value).map(simplifyModel).filter((model) => model !== undefined) });
+      }
+    }
+  }
+
+  private emitError(value: PiWebSession | undefined, error: unknown, clientMessageId?: string) {
+    this.emit({
+      type: "error",
+      ...(value ? { sessionId: value.sessionId, sessionFile: value.sessionFile } : {}),
+      error: errorMessage(error),
+      ...(clientMessageId ? { clientMessageId } : {}),
+    });
+  }
+
+  private emitRuntime(value: PiWebSession, action: "ensure" | "clear" | "changed" | "completed", activitySessionFile?: string) {
+    this.emit({
+      type: "runtime",
+      sessionId: value.sessionId,
+      sessionFile: value.sessionFile,
+      action,
+      ...(activitySessionFile && activitySessionFile !== value.sessionFile ? { activitySessionFile } : {}),
+    });
+  }
+
+  private userMessageFromEvent(event: any) {
+    const value = event?.message;
+    const message = value?.message && typeof value.message === "object" ? value.message : value;
+    const raw = message?.raw || message;
+    return String(message?.role || raw?.role || "") === "user" ? raw : undefined;
+  }
+
+  private takePromptCorrelation(sessionKey: string, event: any) {
+    if (event?.type !== "message_end" || !this.userMessageFromEvent(event)) return undefined;
+    const pending = this.pendingPromptCorrelations.get(sessionKey);
+    if (!pending?.length) return undefined;
+    const cutoff = Date.now() - 60 * 60 * 1000;
+    while (pending[0] && pending[0].createdAt < cutoff) pending.shift();
+    const match = pending.shift();
+    if (!pending.length) this.pendingPromptCorrelations.delete(sessionKey);
+    return match;
+  }
+
+  private rememberPromptCorrelation(sessionKey: string, correlation: PendingPromptCorrelation) {
+    const pending = this.pendingPromptCorrelations.get(sessionKey) || [];
+    pending.push(correlation);
+    this.pendingPromptCorrelations.set(sessionKey, pending);
+  }
+
+  private forgetPromptCorrelation(sessionKey: string, clientMessageId: string) {
+    const pending = this.pendingPromptCorrelations.get(sessionKey)?.filter((item) => item.clientMessageId !== clientMessageId) || [];
+    if (pending.length) this.pendingPromptCorrelations.set(sessionKey, pending);
+    else this.pendingPromptCorrelations.delete(sessionKey);
+  }
+
+  private acquireWorkLease(value: PiWebSession) {
+    const key = sessionPathKey(value);
+    const entry = this.liveSessions.get(key);
+    if (!entry) return () => undefined;
+    entry.workLeases++;
+    this.cancelLiveSessionCleanup(entry);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      entry.workLeases = Math.max(0, entry.workLeases - 1);
+      this.scheduleLiveSessionCleanup(key);
+    };
+  }
+
+  private clearTimer(timer?: ReturnType<typeof setTimeout>) { if (timer) clearTimeout(timer); }
+  private cancelLiveSessionCleanup(entry: LiveSessionEntry) { this.clearTimer(entry.disposeTimer); entry.disposeTimer = undefined; }
+  private isLiveSessionBusy(entry: LiveSessionEntry) { return Boolean(entry.session.isStreaming || entry.session.isCompacting || entry.workLeases > 0); }
+  private shouldKeepLiveSession(entry: LiveSessionEntry) { return this.protectedSessionIds.has(entry.session.sessionId) || entry.viewerClientIds.size > 0 || this.isLiveSessionBusy(entry); }
+
+  private scheduleLiveSessionCleanup(key: string) {
+    const entry = this.liveSessions.get(key);
+    if (!entry || entry.disposing) return;
+    if (this.shouldKeepLiveSession(entry)) { this.cancelLiveSessionCleanup(entry); return; }
+    if (entry.disposeTimer) return;
+    entry.disposeTimer = setTimeout(() => {
+      entry.disposeTimer = undefined;
+      void this.disposeLiveSession(key, "idle");
+    }, this.idleGraceMs);
+  }
+
+  private scheduleViewerLeaseRelease(clientId: string) {
+    const lease = this.viewerLeases.get(clientId);
+    if (!lease || lease.sockets.size > 0) return;
+    this.clearTimer(lease.releaseTimer);
+    lease.releaseTimer = setTimeout(() => this.releaseViewer(clientId), this.viewerGraceMs);
+  }
+
+  private async emitSessionShutdown(value: any) {
+    const runner = value?.extensionRunner;
+    if (runner?.hasHandlers?.("session_shutdown")) await runner.emit({ type: "session_shutdown", reason: "quit" });
+  }
+
+  private async disposeLiveSession(key: string, reason: "idle" | "delete" | "reset", force = false) {
+    const entry = this.liveSessions.get(key);
+    if (!entry || entry.disposing || (!force && this.shouldKeepLiveSession(entry))) return;
+    entry.disposing = true;
+    this.cancelLiveSessionCleanup(entry);
+    const value = entry.session;
+    const sessionId = value.sessionId;
+    const sessionFile = value.sessionFile || key;
+    for (const [clientId, lease] of this.viewerLeases) {
+      if (lease.sessionKey !== key) continue;
+      this.clearTimer(lease.releaseTimer);
+      this.viewerLeases.delete(clientId);
+      for (const connection of lease.sockets) this.viewerConnections.delete(connection);
+      lease.sockets.clear();
+    }
+    try { await this.emitSessionShutdown(value); }
+    catch (error) { console.warn(`Could not emit session shutdown before ${reason}:`, error); }
+    try { entry.unsubscribe?.(); }
+    catch (error) { console.warn(`Could not unsubscribe session before ${reason}:`, error); }
+    try { (value as any).dispose?.(); }
+    catch (error) { console.warn(`Could not dispose session after ${reason}:`, error); }
+    this.liveSessions.delete(key);
+    this.pendingPromptCorrelations.delete(key);
+    if (this.liveById.get(sessionId) === value) this.liveById.delete(sessionId);
+    this.emit({ type: "shutdown", sessionId, sessionFile, sessionKey: key });
+  }
+
+  private rememberSessionLocation(info: { id: string; path: string; cwd?: string }, cwd = this.deps.globalCwd()) {
+    if (info.id && info.path) this.sessionLocations.set(info.id, { path: resolve(info.path), cwd: resolve(info.cwd || cwd) });
+  }
+
+  private simplifySessionInfo(info: PiWebSessionInfo | Awaited<ReturnType<typeof SessionManager.list>>[number], cwd: string): SessionInfoDto {
+    this.rememberSessionLocation(info, cwd);
+    return jsonSafe({
+      id: info.id,
+      path: info.path,
+      name: info.name,
+      firstMessage: info.firstMessage,
+      created: info.created.toISOString(),
+      modified: info.modified.toISOString(),
+      messageCount: info.messageCount,
+      cwd: info.cwd || cwd,
+      isCurrent: false as const,
+    });
+  }
+
+  private async findSessionInfoById(id: string, cwd?: string) {
+    if (!id || this.noSession) return undefined;
+    if (this.deps.sessionFactory?.list) {
+      const infos = await this.deps.sessionFactory.list(cwd || this.deps.globalCwd());
+      return infos.find((info) => info.id === id);
+    }
+    if (cwd?.trim()) {
+      const resolvedCwd = resolve(cwd);
+      const info = (await SessionManager.list(resolvedCwd)).find((item) => item.id === id);
+      if (info?.cwd) this.knownSessionCwds.add(resolve(info.cwd));
+      if (info) return info;
+    }
+    for (const knownCwd of this.knownCwds()) {
+      const info = (await SessionManager.list(knownCwd)).find((item) => item.id === id);
+      if (info?.cwd) this.knownSessionCwds.add(resolve(info.cwd));
+      if (info) return info;
+    }
+    const info = (await SessionManager.listAll()).find((item) => item.id === id);
+    if (info?.cwd) this.knownSessionCwds.add(resolve(info.cwd));
+    return info;
+  }
+
+  private defaultSessionDir(cwd: string) {
+    const safePath = `--${resolve(cwd).replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
+    return join(getAgentDir(), "sessions", safePath);
+  }
+
+  private async resolveSessionLocation(id: string, cwd = this.deps.globalCwd()) {
+    if (!id || this.noSession) return undefined;
+    if (this.deps.sessionFactory?.list) {
+      const info = (await this.deps.sessionFactory.list(cwd)).find((item) => item.id === id);
+      if (info) this.rememberSessionLocation(info, info.cwd || cwd);
+      return info ? this.sessionLocations.get(id) : undefined;
+    }
+    const suffix = `_${id}.jsonl`;
+    for (const resolvedCwd of new Set([resolve(cwd), ...this.knownCwds()])) {
+      let names: string[];
+      try { names = await readdir(this.defaultSessionDir(resolvedCwd)); } catch { continue; }
+      const name = names.find((entry) => entry.endsWith(suffix));
+      if (!name) continue;
+      const location = { path: join(this.defaultSessionDir(resolvedCwd), name), cwd: resolvedCwd };
+      this.sessionLocations.set(id, location);
+      this.knownSessionCwds.add(resolvedCwd);
+      return location;
+    }
+    return undefined;
+  }
+
+  private async openSessionAtLocation(id: string, location: { path: string; cwd: string }) {
+    if (!this.deps.sessionFactory && dirname(resolve(location.path)) !== this.defaultSessionDir(location.cwd)) throw new Error("Invalid session location");
+    const value = await this.getOrCreateLiveSession(location.path);
+    if (value.sessionId !== id) {
+      if (!this.protectedSessionIds.has(value.sessionId)) await this.disposeLiveSession(sessionPathKey(value), "reset", true);
+      throw new Error("Session location did not match requested ID");
+    }
+    this.sessionLocations.set(id, { path: resolve(location.path), cwd: resolve(location.cwd) });
+    return value;
+  }
+
+  private async getOrCreateLiveSession(path: string) {
+    const existing = this.liveSessions.get(path)?.session;
+    if (existing) { this.scheduleLiveSessionCleanup(path); return existing; }
+    const created = await this.makeAgentSession(path);
+    if (created.modelFallbackMessage) console.warn(created.modelFallbackMessage);
+    return this.registerLiveSession(created.session);
+  }
+
+  private async getOrCreateLiveSessionById(id: string, cwd?: string) {
+    const existing = this.liveById.get(id);
+    if (existing) return existing;
+    const pending = this.openingById.get(id);
+    if (pending) return pending;
+    const opening = (async () => {
+      const remembered = this.sessionLocations.get(id);
+      if (remembered) {
+        try { return await this.openSessionAtLocation(id, remembered); }
+        catch { this.sessionLocations.delete(id); }
+      }
+      const location = await this.resolveSessionLocation(id, cwd);
+      return location ? this.openSessionAtLocation(id, location) : undefined;
+    })();
+    this.openingById.set(id, opening);
+    try { return await opening; }
+    finally { this.openingById.delete(id); }
+  }
+
+  private async trashOrRemoveSessionFile(path: string) {
+    try { await execFileAsync("trash", [path], { timeout: 15_000 }); return "trashed" as const; }
+    catch (error: any) {
+      if (error?.code !== "ENOENT") throw error;
+      await rm(path, { force: true });
+      return "deleted" as const;
+    }
+  }
+
+  private getSlashCommands(value: PiWebSession) { return [...webSlashCommands, ...getSessionSlashCommands(value)]; }
+
+  private formatSlashCommandList(commands: SlashCommandDto[]) {
+    const groups: Array<[SlashCommandDto["source"], string]> = [["web", "Web"], ["extension", "Extensions"], ["prompt", "Prompts"], ["skill", "Skills"]];
+    const lines = ["Available slash commands:"];
+    for (const [source, label] of groups) {
+      const matching = commands.filter((command) => command.source === source);
+      if (!matching.length) continue;
+      lines.push("", `${label}:`);
+      for (const command of matching) lines.push(`/${command.name}${command.description ? ` - ${command.description}` : ""}`);
+    }
+    return lines.join("\n");
+  }
+
+  private slashHelp(value: PiWebSession) {
+    return [
+      "Type / in the composer to browse available commands.", "",
+      "Web commands run in pi-web; extension, prompt, and skill commands are discovered from pi's extension/resource system.", "",
+      this.formatSlashCommandList(this.getSlashCommands(value)),
+    ].join("\n");
+  }
+
+  private formatModelList(value: PiWebSession) {
+    return this.availableModels(value).map((model) => `${model.provider}/${model.id}${model.name && model.name !== model.id ? ` (${model.name})` : ""}`).join("\n");
+  }
+
+  private async executeSlashCommand(input: string, value: PiWebSession): Promise<{ message: string; state: BaseSessionStateDto }> {
+    const [rawName = "", ...rest] = input.trim().replace(/^\/+/, "").split(/\s+/);
+    const name = rawName.toLowerCase();
+    const args = rest.join(" ").trim();
+    const state = (session = value) => this.projectState(session);
+    switch (name) {
+      case "help": case "?": return { message: this.slashHelp(value), state: state() };
+      case "commands": return { message: this.formatSlashCommandList(this.getSlashCommands(value)), state: state() };
+      case "reload":
+        if (value.isStreaming) throw new Error("Wait for the current response to finish before reloading.");
+        if (value.isCompacting) throw new Error("Wait for compaction to finish before reloading.");
+        if (!value.reload) throw new Error("Reload is not available in this session.");
+        await value.reload();
+        return { message: "Reloaded pi resources, extensions, and models.", state: state() };
+      case "model": {
+        if (!args) return { message: this.formatModelList(value) || "No models available.", state: state() };
+        const slash = args.indexOf("/");
+        if (slash <= 0) throw new Error("Usage: /model <provider/model-id>");
+        const provider = args.slice(0, slash);
+        const id = args.slice(slash + 1);
+        const model = value.modelRuntime.getModel(provider, id);
+        if (!model) throw new Error(`Model not found: ${args}`);
+        await value.setModel(model);
+        return { message: `Model set to ${provider}/${id}.`, state: state() };
+      }
+      case "models": return { message: this.formatModelList(value) || "No models available.", state: state() };
+      case "thinking": {
+        if (!args) return { message: `Thinking level: ${value.thinkingLevel}\nAvailable: ${value.getAvailableThinkingLevels().join(", ")}`, state: state() };
+        const levels = value.getAvailableThinkingLevels();
+        if (!levels.includes(args)) throw new Error(`Unknown thinking level: ${args}. Available: ${levels.join(", ")}`);
+        value.setThinkingLevel(args);
+        return { message: `Thinking level set to ${value.thinkingLevel}.`, state: state() };
+      }
+      case "new": return { message: "New session.", state: state(await this.createNewLiveSession(this.sessionCwd(value), value.sessionFile)) };
+      case "clear":
+        if (value.isStreaming) throw new Error("Wait for the current response to finish before clearing.");
+        if (value.isCompacting) throw new Error("Wait for compaction to finish before clearing.");
+        return { message: "Cleared tab. Previous session remains in history.", state: state(await this.createNewLiveSession(this.sessionCwd(value), value.sessionFile)) };
+      case "compact": {
+        if (value.isStreaming) throw new Error("Wait for the current response to finish before compacting.");
+        if (value.isCompacting) throw new Error("Compaction is already running.");
+        if (!value.compact) throw new Error("Compaction is not available in this session.");
+        this.emitRuntime(value, "ensure");
+        const release = this.acquireWorkLease(value);
+        void value.compact(args || undefined).catch((error) => {
+          this.emitRuntime(value, "clear");
+          this.emitError(value, error);
+        }).finally(release);
+        return { message: "Compaction started.", state: state() };
+      }
+      case "abort": case "stop":
+        await value.abort();
+        return { message: "Aborted.", state: state() };
+      default: throw new Error(`Unknown slash command: /${name}. Try /help.`);
+    }
+  }
+
+  private async persistPromptImages(images: Array<{ data: string; mimeType: string; name?: string }>, cwd: string) {
+    if (!images.length) return "";
+    await this.ensureStorage(cwd);
+    const uploadDir = join(cwd, ".pi", "web", "uploads");
+    await mkdir(uploadDir, { recursive: true });
+    const lines: string[] = [];
+    for (const image of images) {
+      const extension = imageExtensions[image.mimeType] || ".img";
+      const safeName = String(image.name || "image").replace(/[^a-zA-Z0-9._-]+/g, "_").slice(0, 80);
+      const fileName = `${new Date().toISOString().replace(/[:.]/g, "-")}-${randomUUID()}-${safeName}${safeName.endsWith(extension) ? "" : extension}`;
+      const filePath = join(uploadDir, fileName);
+      await writeFile(filePath, Buffer.from(image.data, "base64"));
+      lines.push(`- ${filePath}`);
+    }
+    return `\n\nAttached image file${images.length === 1 ? "" : "s"}:\n${lines.join("\n")}`;
+  }
+
+  private async startSessionPrompt(value: PiWebSession, input: { message: string; mode: string; images: Array<{ data: string; mimeType: string; name?: string }>; clientMessageId?: string; sourceClientId?: string }) {
+    const imageNote = await this.persistPromptImages(input.images, this.sessionCwd(value));
+    const promptText = `${input.message || "Please review the attached image."}${imageNote}`;
+    if (!this.deps.sessionFactory?.isMock && input.clientMessageId && input.sourceClientId) this.rememberPromptCorrelation(sessionPathKey(value), { clientMessageId: input.clientMessageId, sourceClientId: input.sourceClientId, createdAt: Date.now() });
+    if (!value.isStreaming && !value.isCompacting) this.emitRuntime(value, "ensure");
+    const promptSessionFile = value.sessionFile;
+    const release = this.acquireWorkLease(value);
+    void value.prompt(promptText, {
+      ...(value.isStreaming ? { streamingBehavior: input.mode } : {}),
+      ...(input.images.length ? { images: input.images.map(({ data, mimeType }) => ({ type: "image", data, mimeType })) } : {}),
+    }).catch((error) => {
+      if (!this.deps.sessionFactory?.isMock && input.clientMessageId) this.forgetPromptCorrelation(sessionPathKey(value), input.clientMessageId);
+      this.emitError(value, error, input.clientMessageId);
+    }).finally(() => {
+      this.emitRuntime(value, "completed", promptSessionFile);
+      release();
+    });
+  }
+
+  private trailingRetryTarget(value: PiWebSession): RetrySessionTarget | undefined {
+    const messages = Array.isArray(value.agent?.state?.messages) ? value.agent.state.messages as any[] : [];
+    const index = messages.length - 1;
+    const message = messages[index];
+    if (isAssistantFailureMessage(message)) return { kind: "failure", messages, index, message };
+    if (isAssistantAbortedMessage(message)) return { kind: "aborted", messages, index, message };
+    if (isIncompleteToolResultMessage(message)) return { kind: "toolResult", messages, index, message };
+    return undefined;
+  }
+
+  private branchBeforeTrailingMessages(value: PiWebSession, shouldBranchBefore: (message: any) => boolean) {
+    const manager = value.sessionManager;
+    if (!manager.getBranch) return false;
+    let branch: any[];
+    try { branch = manager.getBranch(); } catch { return false; }
+    if (!Array.isArray(branch)) return false;
+    let last = -1;
+    for (let index = branch.length - 1; index >= 0; index--) if (branch[index]?.type === "message") { last = index; break; }
+    if (last < 0 || !shouldBranchBefore(branch[last]?.message)) return false;
+    let first = last;
+    while (first > 0 && branch[first - 1]?.type === "message" && shouldBranchBefore(branch[first - 1].message)) first--;
+    const parentId = typeof branch[first]?.parentId === "string" ? branch[first].parentId : null;
+    if (parentId && manager.branch) manager.branch(parentId);
+    else if (!parentId && manager.resetLeaf) manager.resetLeaf();
+    else return false;
+    return true;
+  }
+
+  private syncAgentMessages(value: PiWebSession) {
+    if (!value.sessionManager.buildSessionContext) return false;
+    value.agent.state.messages = value.sessionManager.buildSessionContext().messages;
+    return true;
+  }
+
+  private assertCanRetry(value: PiWebSession) {
+    if (value.isStreaming) throw new Error("Wait for the current response to finish before retrying.");
+    if (value.isCompacting) throw new Error("Wait for compaction to finish before retrying.");
+    if (!this.trailingRetryTarget(value)) throw new Error("There is no failed or incomplete response to retry.");
+  }
+
+  private async retryFromFailure(value: PiWebSession) {
+    this.assertCanRetry(value);
+    if (value.retryFromFailure) return value.retryFromFailure();
+    const target = this.trailingRetryTarget(value);
+    if (!target) throw new Error("There is no failed or incomplete response to retry.");
+    const internal = value as any;
+    if (!internal.agent || typeof internal.agent.continue !== "function") throw new Error("Continuing is not available in this session.");
+    if (target.kind === "failure") {
+      if (!this.branchBeforeTrailingMessages(value, isAssistantFailureMessage) || !this.syncAgentMessages(value)) while (target.messages.length && isAssistantFailureMessage(target.messages.at(-1))) target.messages.pop();
+    } else if (target.kind === "aborted") {
+      if (!this.branchBeforeTrailingMessages(value, isAssistantAbortedMessage) || !this.syncAgentMessages(value)) if (isAssistantAbortedMessage(target.messages.at(-1))) target.messages.pop();
+    }
+    try {
+      await internal.agent.continue();
+      while (typeof internal._handlePostAgentRun === "function" && await internal._handlePostAgentRun()) await internal.agent.continue();
+    } finally {
+      internal._systemPromptOverride = undefined;
+      internal._flushPendingBashMessages?.();
+    }
+  }
+
+  private async startSessionRetry(value: PiWebSession) {
+    try { this.assertCanRetry(value); } catch (error) { throw new SessionServiceError(errorMessage(error), 409); }
+    this.emitRuntime(value, "ensure");
+    const retrySessionFile = value.sessionFile;
+    const release = this.acquireWorkLease(value);
+    void this.retryFromFailure(value).catch((error) => {
+      this.emitRuntime(value, "clear", retrySessionFile);
+      this.emitError(value, error);
+    }).finally(() => {
+      this.emitRuntime(value, "completed", retrySessionFile);
+      release();
+    });
+  }
+
+  private openExtensionSession(sessionId: string) {
+    const value = this.liveById.get(sessionId);
+    if (!value) throw new SessionServiceError("Session is not currently open.", 404);
+    return value;
+  }
 }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -353,6 +353,36 @@ describe("pi-web mock API", () => {
     expect(state.sessionName).toBeUndefined();
   });
 
+  it("clears queued mock prompt correlations on reset", async () => {
+    await fetch(`${baseUrl}/api/mock/reset`, { method: "POST" });
+    const ws = new WebSocket(`ws://127.0.0.1:${new URL(baseUrl).port}/ws?sessionId=mock-current`);
+    await once(ws, "open");
+    const events: any[] = [];
+    ws.on("message", (data) => events.push(JSON.parse(String(data))));
+    const headers = { "content-type": "application/json", "x-pi-web-client-id": "correlation-client" };
+
+    await fetch(`${baseUrl}/api/prompt`, {
+      method: "POST", headers,
+      body: JSON.stringify({ message: "slow correlation run", clientMessageId: "first-message" }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await fetch(`${baseUrl}/api/prompt`, {
+      method: "POST", headers,
+      body: JSON.stringify({ message: "queued before reset", mode: "followUp", clientMessageId: "stale-message" }),
+    });
+    await fetch(`${baseUrl}/api/mock/reset`, { method: "POST" });
+    events.length = 0;
+    await fetch(`${baseUrl}/api/prompt`, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message: "after correlation reset" }),
+    });
+    await waitForCondition(() => events.some((event) => event.type === "pi_event" && event.event?.type === "message_end" && event.event?.message?.content === "after correlation reset"));
+    const nextUserEvent = events.find((event) => event.type === "pi_event" && event.event?.message?.content === "after correlation reset");
+    expect(nextUserEvent).not.toHaveProperty("clientMessageId");
+    expect(nextUserEvent).not.toHaveProperty("sourceClientId");
+    ws.close();
+  });
+
   it("rejects empty prompts", async () => {
     const res = await fetch(`${baseUrl}/api/prompt`, {
       method: "POST",
@@ -480,6 +510,7 @@ describe("pi-web mock API", () => {
     const missing = "does-not-exist";
     const cases: Array<[string, RequestInit, number]> = [
       [`/api/state?sessionId=${missing}`, {}, 404],
+      ["/api/state?sessionId=%20", {}, 404],
       [`/api/messages?sessionId=${missing}`, {}, 404],
       ["/api/sessions/open", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ id: missing }) }, 404],
       ["/api/session/cwd", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ sessionId: missing, cwd: "/tmp" }) }, 404],

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -33,16 +33,16 @@ describe("agent context organization", () => {
     expect(existsSync(join(root, "contexts/pi-web-development.md"))).toBe(false);
   });
 
-  it("server injects only generic web UI context and relies on Pi to load AGENTS.md", async () => {
-    const server = await text("server.ts");
+  it("the self-contained session service injects only generic web UI context and relies on Pi to load AGENTS.md", async () => {
+    const service = await text("server/session/service.ts");
 
-    expect(server).toContain('const webUiContextFile = join(appDir, "contexts", "web-ui.md")');
-    expect(server).toContain("appendSystemPromptOverride");
-    expect(server).toContain("webUiContext");
+    expect(service).toContain('new URL("../../contexts/web-ui.md", import.meta.url)');
+    expect(service).toContain("appendSystemPromptOverride");
+    expect(service).toContain("webUiContext");
 
-    expect(server).not.toContain("piWebDevelopmentContextFile");
-    expect(server).not.toContain("pi-web-development.md");
-    expect(server).not.toContain("piCwd === appDir ?");
-    expect(server).not.toContain("pi-web-agent-context.md");
+    expect(service).not.toContain("piWebDevelopmentContextFile");
+    expect(service).not.toContain("pi-web-development.md");
+    expect(service).not.toContain("piCwd === appDir ?");
+    expect(service).not.toContain("pi-web-agent-context.md");
   });
 });

--- a/tests/session-service.test.ts
+++ b/tests/session-service.test.ts
@@ -1,76 +1,407 @@
-import { readFile } from "node:fs/promises";
-import { describe, expect, it, vi } from "vitest";
-import { jsonRoundTrip } from "../server/session/dto.js";
-import { LocalSessionService, type LocalSessionServiceDependencies } from "../server/session/service.js";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { jsonRoundTrip, type MessageDto, type SessionServiceEvent } from "../server/session/dto.js";
+import { SessionActivity } from "../server/session/activity.js";
+import { createHostSessionEventHandler, decorateHostMessages, resolveWebSocketHelloSession } from "../server/session/hostEvents.js";
+import { LocalSessionService, type LocalSessionFactory, type LocalSessionServiceDependencies } from "../server/session/service.js";
 import type { PiWebSession } from "../server/types.js";
 
-function fixtureSession(): PiWebSession {
-  const entries = [
-    { id: "call", parentId: null, type: "message", timestamp: "2026-01-01T00:00:00Z", message: { role: "assistant", content: [{ type: "toolCall", id: "t1", toolName: "read", args: { path: "secret" }, startedAt: "2026-01-01T00:00:00Z" }], timestamp: "2026-01-01T00:00:00Z" } },
+const tempDirs: string[] = [];
+let fixtureSessionSequence = 0;
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  await Promise.all(tempDirs.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+function fixtureSession(cwd: string, id = "current", path = join(cwd, `${id}.jsonl`)) {
+  const entries: any[] = [
+    { id: "call", parentId: null, type: "message", timestamp: "2026-01-01T00:00:00Z", message: { role: "assistant", content: [{ type: "toolCall", id: "t1", toolName: "read", arguments: { path: "secret" } }], timestamp: "2026-01-01T00:00:00Z" } },
     { id: "result", parentId: "call", type: "message", timestamp: "2026-01-01T00:00:01Z", message: { role: "toolResult", toolCallId: "t1", toolName: "read", content: [{ type: "text", text: "ok" }], isError: false, timestamp: "2026-01-01T00:00:01Z" } },
   ];
+  const listeners = new Set<(event: unknown) => void>();
   const model = { provider: "test", id: "model", name: "Model", reasoning: true, contextWindow: 1000, maxTokens: 100 };
-  return {
-    sessionId: "current", sessionFile: "/tmp/current.jsonl", isStreaming: false, isCompacting: false,
-    model, thinkingLevel: "medium", messages: entries.map((entry) => entry.message), agent: { state: { messages: entries.map((entry) => entry.message) } },
-    sessionManager: { newSession() {}, getBranch: () => entries, getLeafId: () => "result", getTree: () => [{ entry: entries[0], children: [{ entry: entries[1], children: [] }] }] },
+  let session: PiWebSession;
+  let extensionOptions: any;
+  let disposeCalls = 0;
+  const syncMessages = () => {
+    const messages = entries.map((entry) => entry.message);
+    session.messages = messages;
+    session.agent.state.messages = messages;
+  };
+  session = {
+    sessionId: id, sessionFile: path, isStreaming: false, isCompacting: false,
+    model, thinkingLevel: "medium", messages: [], agent: { state: { messages: [] } },
+    sessionManager: {
+      newSession() {
+        session.sessionId = `created-${++fixtureSessionSequence}`;
+        session.sessionFile = join(cwd, `${session.sessionId}.jsonl`);
+        entries.splice(0);
+        syncMessages();
+      },
+      buildSessionContext: () => ({ messages: entries.map((entry) => entry.message) }),
+      getBranch: () => entries,
+      getLeafId: () => entries.at(-1)?.id || null,
+      getTree: () => entries.length ? [{ entry: entries[0], children: entries.slice(1).map((entry) => ({ entry, children: [] })) }] : [],
+      getSessionName: () => "Fixture",
+      getCwd: () => cwd,
+    } as PiWebSession["sessionManager"],
     modelRuntime: { getAvailableSnapshot: () => [model], getModel: () => model },
     extensionRunner: { getRegisteredCommands: () => [] }, promptTemplates: [], resourceLoader: { getSkills: () => ({ skills: [] }) },
+    bindExtensions: async (options) => { extensionOptions = options; },
     getAvailableThinkingLevels: () => ["off", "medium"], getSessionName: () => "Fixture", getContextUsage: () => ({ tokens: 1, contextWindow: 1000, percent: 0.1 }),
-    setModel: vi.fn(async () => undefined), setThinkingLevel: vi.fn(), prompt: async () => undefined, abort: async () => undefined,
+    setSessionName: (name) => { session.sessionName = name; },
+    setModel: vi.fn(async () => undefined), setThinkingLevel: vi.fn(), abort: async () => undefined,
+    navigateTree: async () => ({ cancelled: false, editorText: "draft" }),
+    prompt: async (message) => {
+      const eventMessage = { role: "user", content: message, timestamp: "2026-01-01T00:00:02Z" };
+      entries.push({ id: `user-${entries.length}`, parentId: entries.at(-1)?.id || null, type: "message", timestamp: eventMessage.timestamp, message: eventMessage });
+      syncMessages();
+      listeners.forEach((listener) => listener({ type: "message_end", message: eventMessage }));
+    },
+    subscribe: (listener) => { listeners.add(listener); return () => listeners.delete(listener); },
+  };
+  (session as any).dispose = () => { disposeCalls++; };
+  syncMessages();
+  return {
+    session,
+    emit(event: unknown) { listeners.forEach((listener) => listener(event)); },
+    get extensionOptions() { return extensionOptions; },
+    get disposeCalls() { return disposeCalls; },
   };
 }
 
-function fixtureService() {
-  const session = fixtureSession();
-  const creates: Array<{ cwd?: string; previous?: string }> = [];
-  const deps: LocalSessionServiceDependencies = {
-    currentSessionId: () => "current", globalCwd: () => "/global", resolve: async (id) => id === "current" ? session : undefined,
-    cwd: () => "/current", decorateState: () => ({ sessionId: "current", cwd: "/current", model: { provider: "test", id: "model" } }),
-    decorateMessageContent: (content) => content, availableModels: () => [session.model], webCommands: [{ name: "web", source: "web" }],
-    list: async () => [], create: async (cwd, previous) => { creates.push({ cwd, previous }); return session; }, open: async () => session,
-    delete: async () => ({}), switchCwd: async () => ({}), executeCommand: async () => ({ message: "ok", state: {} }), prompt: async () => undefined,
-    retry: async () => undefined, navigate: async () => ({ finish() {} }), invokeHeaderAction: async () => ({}), invokeArtifactAction: async (_session, input) => input, invokeGitTab: async () => ({}), reportError: () => undefined,
+type FixtureServiceOptions = {
+  isMock?: boolean;
+  finalizeCreatedSession?: (sessionId: string) => Promise<unknown>;
+  list?: LocalSessionFactory["list"];
+};
+
+async function fixtureService(options: FixtureServiceOptions = {}) {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-web-service-"));
+  tempDirs.push(cwd);
+  const sessions = new Map<string, ReturnType<typeof fixtureSession>>();
+  const creates: Array<{ cwd: string; path?: string; reason?: string; previous?: string }> = [];
+  const factory: LocalSessionFactory = {
+    isMock: options.isMock,
+    async create(input) {
+      creates.push({ cwd: input.cwd, path: input.path, reason: input.sessionStartEvent?.reason, previous: input.sessionStartEvent?.previousSessionFile });
+      const id = input.path ? input.path.split("/").at(-1)?.replace(/\.jsonl$/, "") || "opened" : creates.length === 1 ? "current" : `factory-${creates.length}`;
+      const value = fixtureSession(input.cwd, id, input.path);
+      sessions.set(id, value);
+      return { session: value.session };
+    },
+    list: options.list || (async () => []),
   };
-  return { service: new LocalSessionService(deps), session, creates };
+  const deps: LocalSessionServiceDependencies = {
+    modelRuntime: {} as LocalSessionServiceDependencies["modelRuntime"],
+    sessionFactory: factory,
+    additionalExtensionPaths: () => [],
+    sessionConfig: {
+      defaultsFor: async () => ({}),
+      finalizeCreatedSession: options.finalizeCreatedSession || (async () => undefined),
+    },
+    globalCwd: () => cwd,
+    clientCount: () => 0,
+  };
+  const service = new LocalSessionService(deps);
+  const initial = await service.initialize();
+  return { service, initial, fixture: sessions.get("current")!, creates, cwd };
 }
 
 describe("LocalSessionService contract", () => {
-  it("returns JSON-round-trip-stable projection results", async () => {
-    const { service } = fixtureService();
-    for (const result of await Promise.all([service.state(), service.stats(), service.tree(), service.messages(), service.models(), service.commands()])) {
-      expect(jsonRoundTrip(result)).toStrictEqual(result);
-    }
+  it("constructs and works standalone without importing server.ts", async () => {
+    const { service, initial } = await fixtureService();
+    const events: SessionServiceEvent[] = [];
+    service.subscribe((event) => events.push(event));
+
+    const created = await service.create(initial.sessionId);
+    await service.prompt(created.sessionId, { message: "hello", mode: "steer", images: [] });
+
+    expect((await service.state(created.sessionId)).sessionId).toBe(created.sessionId);
+    expect(await service.messages(created.sessionId)).toContainEqual(expect.objectContaining({ role: "user", text: "hello" }));
+    expect(events.map((event) => event.type)).toContain("pi");
+    expect(events.map((event) => event.type)).toContain("stats");
+
+    initial.prompt = async () => { throw new Error("prompt failed"); };
+    await service.prompt(initial.sessionId, { message: "fail", mode: "steer", images: [] });
+    await vi.waitFor(() => expect(events.map((event) => event.type)).toContain("error"));
+    await service.disposeAll("reset");
+    expect(events.map((event) => event.type)).toContain("shutdown");
+    for (const event of events) expect(jsonRoundTrip(event)).toStrictEqual(event);
   });
 
-  it("delegates artifact action invocation for the resolved session", async () => {
-    const { service } = fixtureService();
-    await expect(service.invokeArtifactAction(undefined, { key: "download", path: "/api/artifacts/report.md" }))
-      .resolves.toEqual({ key: "download", path: "/api/artifacts/report.md" });
+  it("returns JSON-round-trip-stable projection results and events", async () => {
+    const { service, fixture, initial } = await fixtureService();
+    const events: SessionServiceEvent[] = [];
+    service.subscribe((event) => events.push(event));
+    fixture.emit({ type: "session_info_changed", name: "Renamed" });
+    fixture.emit({ type: "message_end", message: { role: "assistant", model: "blocked", errorMessage: "model_not_supported" } });
+
+    const results = await Promise.all([
+      service.state(initial.sessionId), service.stats(initial.sessionId), service.tree(initial.sessionId),
+      service.messages(initial.sessionId), service.models(initial.sessionId), service.commands(initial.sessionId),
+      service.setModel(initial.sessionId, "test", "model"), service.rename(initial.sessionId, "Renamed"),
+      service.open(initial.sessionId), service.create(initial.sessionId),
+    ]);
+    for (const result of results) expect(jsonRoundTrip(result)).toStrictEqual(result);
+    expect(events.map((event) => event.type)).toEqual(["pi", "state", "pi", "stats", "models"]);
+    for (const event of events) expect(jsonRoundTrip(event)).toStrictEqual(event);
+  });
+
+  it("keeps navigation data serializable and its finalizer serving-side", async () => {
+    const { service, initial } = await fixtureService();
+    const { finish, ...result } = await service.navigate(initial.sessionId, "result", {});
+    expect(jsonRoundTrip(result)).toStrictEqual(result);
+    expect(finish).toEqual(expect.any(Function));
+    finish();
   });
 
   it("maps unavailable conversation trees to the legacy 400 status", async () => {
-    const { service, session } = fixtureService();
-    session.sessionManager.getTree = undefined;
-    await expect(service.tree()).rejects.toMatchObject({ status: 400 });
+    const { service, initial } = await fixtureService();
+    initial.sessionManager.getTree = undefined;
+    await expect(service.tree(initial.sessionId)).rejects.toMatchObject({ status: 400 });
   });
 
   it("preserves message args and empty thinking-level behavior", async () => {
-    const { service, session } = fixtureService();
-    const messages = await service.messages() as Array<Record<string, unknown>>;
-    expect(messages[1].toolArgs).toEqual({});
-    await service.setModel(undefined, "test", "model", "");
-    expect(session.setThinkingLevel).toHaveBeenCalledWith("");
+    const { service, initial } = await fixtureService();
+    const messages = await service.messages(initial.sessionId);
+    expect(messages[1].toolArgs).toEqual({ path: "secret" });
+    await service.setModel(initial.sessionId, "test", "model", "");
+    expect(initial.setThinkingLevel).toHaveBeenCalledWith("");
   });
 
-  it("inherits the current session but lets unknown sources fall back globally", async () => {
-    const { service, creates } = fixtureService();
-    await service.create();
+  it("implicitly inherits the current session but lets unknown sources fall back globally", async () => {
+    const { service, initial, creates, cwd } = await fixtureService();
+    const currentCwd = await mkdtemp(join(cwd, "current-cwd-"));
+    initial.sessionManager.getCwd = () => currentCwd;
+    await service.create(undefined);
     await service.create("missing");
-    expect(creates).toEqual([
-      { cwd: "/current", previous: "/tmp/current.jsonl" },
-      { cwd: "/global", previous: undefined },
+    expect(creates.slice(1)).toEqual([
+      { cwd: currentCwd, path: undefined, reason: "new", previous: initial.sessionFile },
+      { cwd, path: undefined, reason: "new", previous: undefined },
     ]);
+  });
+
+  it("delegates artifact actions for the implicitly resolved current session", async () => {
+    const { service, fixture } = await fixtureService();
+    const invoke = vi.fn(() => ({ message: "downloaded" }));
+    fixture.extensionOptions.uiContext.web.setArtifactAction("download", { invoke });
+    const input = { key: "download", name: "report.md", path: "/api/artifacts/report.md", kind: "markdown" };
+    await expect(service.invokeArtifactAction(undefined, input)).resolves.toEqual({ label: "download", message: "downloaded" });
+    expect(invoke).toHaveBeenCalledWith({ name: "report.md", path: "/api/artifacts/report.md", kind: "markdown" });
+  });
+
+  it("preserves duplicate session IDs returned by different cwd listings", async () => {
+    const modified = new Date("2026-01-02T00:00:00Z");
+    const { service, cwd } = await fixtureService({
+      list: async (listedCwd) => [{ id: "duplicate", path: join(listedCwd, "duplicate.jsonl"), created: modified, modified, messageCount: 1, cwd: listedCwd }],
+    });
+    const extraCwd = await mkdtemp(join(cwd, "extra-cwd-"));
+    expect((await service.list([extraCwd])).map((info) => info.id)).toEqual(["duplicate", "duplicate"]);
+  });
+
+  it("runs the host post-create finalizer before extension-created state publication", async () => {
+    const order: string[] = [];
+    const { service, fixture } = await fixtureService({
+      finalizeCreatedSession: async () => { order.push("session_ui_state_changed"); },
+    });
+    service.subscribe((event) => {
+      if (event.type === "wire" && (event.value as any).type === "state_changed") order.push("state_changed");
+    });
+    await fixture.extensionOptions.commandContextActions.newSession();
+    expect(order).toEqual(["session_ui_state_changed", "state_changed"]);
+  });
+
+  it("keeps the dependency surface to six true externals", async () => {
+    const source = await readFile(new URL("../server/session/service.ts", import.meta.url), "utf8");
+    const body = source.slice(source.indexOf("export interface LocalSessionServiceDependencies"), source.indexOf("}\n\ntype LiveSessionEntry"));
+    expect(body.match(/^  \w+[^\n]*;/gm)).toHaveLength(6);
+    expect(body).not.toContain("decorateState");
+    expect(body).not.toContain("resolve(sessionId");
+  });
+
+  it("executes the synchronous service-to-host event pipeline with exact wire payloads", async () => {
+    const { service, fixture, initial } = await fixtureService();
+    const activity = new SessionActivity((path) => service.sessionForPath(path));
+    const wire: any[] = [];
+    service.subscribe(createHostSessionEventHandler({
+      sessionForId: (id) => service.sessionForId(id),
+      projectState: (value) => service.projectState(value),
+      webUiEntries: (value) => service.webUiEntries(value),
+      sessionActivity: activity,
+      broadcast: (value) => wire.push(value),
+      markSessionUnreadCompleted: () => undefined,
+    }));
+
+    initial.isStreaming = true;
+    const startedAt = "2026-02-01T00:00:00.000Z";
+    const firstActivityAt = "2026-02-01T00:00:01.000Z";
+    fixture.emit({ type: "agent_start", startedAt, lastActivityAt: firstActivityAt });
+    expect(wire).toEqual([
+      { type: "pi_event", sessionId: initial.sessionId, sessionFile: initial.sessionFile, event: { type: "agent_start", startedAt, lastActivityAt: firstActivityAt } },
+      { type: "session_runtime_changed", sessionId: initial.sessionId, sessionFile: initial.sessionFile, runtime: activity.runtimeForPath(initial.sessionFile) },
+    ]);
+
+    wire.length = 0;
+    fixture.emit({ type: "session_info_changed", name: "Renamed" });
+    const { thinkingLevels: _thinkingLevels, ...stateWithoutThinkingLevels } = service.projectState(initial);
+    expect(wire).toEqual([
+      { type: "pi_event", sessionId: initial.sessionId, sessionFile: initial.sessionFile, event: { type: "session_info_changed", name: "Renamed" } },
+      { type: "session_runtime_changed", sessionId: initial.sessionId, sessionFile: initial.sessionFile, runtime: activity.runtimeForPath(initial.sessionFile) },
+      {
+        type: "state_changed",
+        ...stateWithoutThinkingLevels,
+        runtimeStartedAt: startedAt,
+        runtimeLastActivityAt: firstActivityAt,
+        runtime: activity.runtimeForPath(initial.sessionFile),
+        webFooters: [], webHeaderActions: [], webArtifactActions: [], webGitTabs: [],
+      },
+    ]);
+
+    wire.length = 0;
+    const messageAt = "2026-02-01T00:00:02.000Z";
+    const message = { role: "assistant", model: "model", errorMessage: "model_not_supported", timestamp: messageAt };
+    fixture.emit({ type: "message_end", message, timestamp: messageAt });
+    expect(wire).toEqual([
+      { type: "pi_event", sessionId: initial.sessionId, sessionFile: initial.sessionFile, event: { type: "message_end", message, timestamp: messageAt, lastActivityAt: messageAt } },
+      { type: "session_runtime_changed", sessionId: initial.sessionId, sessionFile: initial.sessionFile, runtime: activity.runtimeForPath(initial.sessionFile) },
+      { type: "session_stats_changed", sessionId: initial.sessionId, sessionFile: initial.sessionFile, stats: (await service.stats(initial.sessionId)).stats },
+      { type: "models_updated", sessionId: initial.sessionId, models: [] },
+    ]);
+  });
+
+  it("propagates WebSocket open failures but keeps unknown-ID fallback eligible", async () => {
+    const { initial } = await fixtureService();
+    await expect(resolveWebSocketHelloSession("unknown", initial, async () => undefined)).resolves.toBeUndefined();
+    await expect(resolveWebSocketHelloSession("corrupt", initial, async () => { throw new Error("corrupt session"); })).rejects.toThrow("corrupt session");
+  });
+
+  it("decorates ID-less tool calls by their matching content position", () => {
+    const activity = new SessionActivity(() => undefined);
+    const sessionFile = "/tmp/id-less.jsonl";
+    activity.enrichEvent({ sessionFile, sessionId: "id-less" } as PiWebSession, { type: "tool_execution_start", toolName: "read", startedAt: "2026-03-01T00:00:00.000Z" });
+    const messages: MessageDto[] = [{
+      toolCalls: [{ toolName: "read", args: {} }],
+      raw: { role: "assistant", content: [{ type: "toolCall", toolName: "read", arguments: {} }] },
+    }];
+    expect(decorateHostMessages(messages, sessionFile, activity)[0].toolCalls).toEqual([
+      { toolName: "read", args: {}, startedAt: "2026-03-01T00:00:00.000Z" },
+    ]);
+  });
+});
+
+describe("LocalSessionService standalone lifecycle", () => {
+  it("honors viewer and work leases through their grace timers", async () => {
+    vi.stubEnv("PI_WEB_SESSION_IDLE_GRACE_MS", "30");
+    vi.stubEnv("PI_WEB_VIEWER_LEASE_GRACE_MS", "20");
+    const { service } = await fixtureService();
+    vi.useFakeTimers();
+
+    const viewed = await service.create(undefined);
+    service.acquireViewer(viewed.sessionId, "viewer");
+    await vi.advanceTimersByTimeAsync(19);
+    expect(service.lifecycleSnapshot().viewerLeases).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(service.lifecycleSnapshot().viewerLeases).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(30);
+    expect(service.sessionForId(viewed.sessionId)).toBeUndefined();
+
+    const working = await service.create(undefined);
+    const navigation = await service.navigate(working.sessionId, "result", {});
+    await vi.advanceTimersByTimeAsync(100);
+    expect(service.sessionForId(working.sessionId)).toBeDefined();
+    navigation.finish();
+    await vi.advanceTimersByTimeAsync(30);
+    expect(service.sessionForId(working.sessionId)).toBeUndefined();
+  });
+
+  it("does not let a stale socket release a replacement viewer lease", async () => {
+    const { service, cwd } = await fixtureService();
+    const first = await service.create(undefined);
+    service.acquireViewer(first.sessionId, "client");
+    const staleConnection = service.connectViewer("client")!;
+
+    await service.disposeAll("reset");
+    const replacement = fixtureSession(cwd, "replacement").session;
+    service.setCurrentSession(replacement);
+    service.acquireViewer(replacement.sessionId, "client");
+    const activeConnection = service.connectViewer("client")!;
+
+    service.disconnectViewer(staleConnection);
+    expect(service.lifecycleSnapshot().viewerLeases).toEqual([
+      expect.objectContaining({ clientId: "client", sockets: 1 }),
+    ]);
+    expect(service.lifecycleSnapshot().liveSessions).toEqual([
+      expect.objectContaining({ sessionId: "replacement", viewerLeases: 1 }),
+    ]);
+    service.disconnectViewer(activeConnection);
+  });
+
+  it("isolates concurrent disposal and disposes each runtime once", async () => {
+    const { service, initial, fixture } = await fixtureService();
+    let releaseShutdown!: () => void;
+    const shutdown = new Promise<void>((resolve) => { releaseShutdown = resolve; });
+    const emit = vi.fn(() => shutdown);
+    initial.extensionRunner = { hasHandlers: () => true, emit } as any;
+
+    const first = service.disposeAll("reset");
+    const second = service.disposeAll("reset");
+    await Promise.resolve();
+    expect(emit).toHaveBeenCalledTimes(1);
+    releaseShutdown();
+    await Promise.all([first, second]);
+    expect(fixture.disposeCalls).toBe(1);
+  });
+
+  it("resets mock lifecycle state, leases, and registrations standalone", async () => {
+    const { service, initial, fixture, cwd } = await fixtureService({ isMock: true });
+    service.acquireViewer(initial.sessionId, "mock-client");
+    service.connectViewer("mock-client");
+    const replacementFixture = fixtureSession(cwd, "mock-reset");
+
+    await service.resetWith(replacementFixture.session);
+
+    expect(fixture.disposeCalls).toBe(1);
+    expect(service.sessionForId(initial.sessionId)).toBeUndefined();
+    expect(service.sessionForId("mock-reset")).toBe(replacementFixture.session);
+    expect(service.lifecycleSnapshot().viewerLeases).toEqual([]);
+  });
+
+  it("captures operation paths and clears both registration and current paths on shutdown", async () => {
+    const { service, initial } = await fixtureService();
+    const activity = new SessionActivity((path) => service.sessionForPath(path));
+    const wire: unknown[] = [];
+    service.subscribe(createHostSessionEventHandler({
+      sessionForId: (id) => service.sessionForId(id),
+      projectState: (value) => service.projectState(value),
+      webUiEntries: (value) => service.webUiEntries(value),
+      sessionActivity: activity,
+      broadcast: (value) => wire.push(value),
+      markSessionUnreadCompleted: () => undefined,
+    }));
+
+    let finishPrompt!: () => void;
+    initial.prompt = () => new Promise<void>((resolve) => { finishPrompt = resolve; });
+    const events: SessionServiceEvent[] = [];
+    service.subscribe((event) => events.push(event));
+    const originalFile = initial.sessionFile;
+    await service.prompt(initial.sessionId, { message: "move", mode: "steer", images: [] });
+    const movedFile = join(originalFile, "moved.jsonl");
+    initial.sessionFile = movedFile;
+    finishPrompt();
+    await vi.waitFor(() => expect(events.some((event) => event.type === "runtime" && event.action === "completed")).toBe(true));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "runtime", action: "completed", sessionFile: movedFile, activitySessionFile: originalFile,
+    }));
+
+    activity.noteEvent(originalFile, { type: "agent_start", startedAt: "2026-04-01T00:00:00.000Z" });
+    activity.noteEvent(movedFile, { type: "agent_start", startedAt: "2026-04-01T00:00:00.000Z" });
+    await service.disposeAll("reset");
+    expect(activity.hasStarted(originalFile)).toBe(false);
+    expect(activity.hasStarted(movedFile)).toBe(false);
   });
 });
 
@@ -81,7 +412,7 @@ describe("session route boundary", () => {
     expect(routes).not.toContain("targetSession.");
   });
 
-  it("writes a navigation response before calling its finalizer", async () => {
+  it("writes a navigation response before calling its serving-side finalizer", async () => {
     const source = await readFile(new URL("../server.ts", import.meta.url), "utf8");
     const start = source.indexOf('url.pathname === "/api/session/tree/navigate"');
     const route = source.slice(start, source.indexOf('url.pathname === "/api/session/tree/abort-summary"', start));


### PR DESCRIPTION
## Summary

Closes #67.

- move live-session lifecycle, caching, leases, disposal, creation, lookup, and operations behind `LocalSessionService`
- replace the server-owned closure bag with six true external dependencies
- invert session events through a typed, JSON-serializable `SessionServiceEvent` subscription API while preserving host-side activity decoration and wire ordering
- strengthen session state, message, model, list, delete, and navigation DTOs
- keep navigation finalization explicitly serving-side and non-serializable
- add a standalone service test that creates, prompts, reads state/messages, and captures events without importing `server.ts`
- refresh the staged runtime-binding design through the future runner/router/provider stages

## Architecture

`server.ts` is reduced from 1,821 to 945 lines and now focuses on HTTP plumbing, host decoration, realtime/unread handling, stores, and service wiring. Box-local session lifecycle and operations live in `server/session/service.ts`.

## Validation

- `npm run typecheck`
- `npm run test:unit` — 153 passed
- `npm run build`
- `npm test` — all tasks passed across unit, build, auth, desktop, mobile, and tablet shards
- `git diff --check`

The full E2E run had a few existing tests retry successfully as flaky; no shard or test task failed.
