### PR TITLE
Fix leaked session work leases

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -722,6 +722,10 @@ const server = createServer(async (req, res) => {
         }
       }
 
+      if (method === "GET" && url.pathname === "/api/session/lifecycle") {
+        return sendJson(res, 200, { ok: true, ...sessionService.lifecycleSnapshot() });
+      }
+
       if (method === "GET" && url.pathname === "/api/session/stats") {
         return sendJson(res, 200, { ok: true, ...await sessionService.stats(resolveSessionId(url.searchParams.get("sessionId"))) });
       }
@@ -736,18 +740,14 @@ const server = createServer(async (req, res) => {
         await sessionService.require(requestedSessionId);
         const targetId = String(body.targetId || "").trim();
         if (!targetId) return sendJson(res, 400, { ok: false, error: "targetId is required" });
-        const { finish, state: baseState, ...result } = await sessionService.navigate(requestedSessionId, targetId, {
+        const { state: baseState, ...result } = await sessionService.navigate(requestedSessionId, targetId, {
           summarize: Boolean(body.summarize),
           customInstructions: typeof body.customInstructions === "string" && body.customInstructions.trim() ? body.customInstructions.trim() : undefined,
           replaceInstructions: Boolean(body.replaceInstructions),
           label: typeof body.label === "string" && body.label.trim() ? body.label.trim() : undefined,
         });
         const state = await decorateServiceState(baseState);
-        try {
-          return sendJson(res, 200, { ok: true, ...result, state });
-        } finally {
-          finish();
-        }
+        return sendJson(res, 200, { ok: true, ...result, state });
       }
 
       if (method === "POST" && url.pathname === "/api/session/tree/abort-summary") {

--- a/server/extensions/webUi.ts
+++ b/server/extensions/webUi.ts
@@ -8,7 +8,7 @@ import { canonicalSchemaKey, defaultSettingsValues, validateSettingsValues } fro
 export interface WebUiBridgeDependencies {
   emit(value: unknown): void;
   clientCount(): number;
-  acquireWorkLease(session: any): () => void;
+  withWorkLease<T>(session: any, label: string, operation: () => Promise<T>): Promise<T>;
   createNewSession(cwd: string, previousSessionFile?: string): Promise<any>;
   sessionCwd(session: any): string;
   state(session: any): Record<string, unknown>;
@@ -574,9 +574,8 @@ function requestInteraction<T>(
 ): Promise<T> {
   if (opts?.signal?.aborted || deps.clientCount() === 0) return Promise.resolve(defaultValue);
 
-  return new Promise<T>((resolvePromise) => {
+  return deps.withWorkLease(value, `extension-interaction:${method}`, () => new Promise<T>((resolvePromise) => {
     const id = randomUUID();
-    const releaseWorkLease = deps.acquireWorkLease(value);
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutMs = opts?.timeout ?? 120_000;
 
@@ -584,7 +583,6 @@ function requestInteraction<T>(
       if (timeoutId) clearTimeout(timeoutId);
       opts?.signal?.removeEventListener("abort", onAbort);
       pendingInteractionRequests.delete(id);
-      releaseWorkLease();
     };
     const finish = (result: T) => {
       cleanup();
@@ -611,7 +609,7 @@ function requestInteraction<T>(
       sessionFile: value.sessionFile,
       timeout: timeoutMs,
     });
-  });
+  }));
 }
 
 function createWebExtensionUiContext(value: any): ExtensionUIContext & { web: PiWebUi } {

--- a/server/session/dto.ts
+++ b/server/session/dto.ts
@@ -194,14 +194,8 @@ export type SessionServiceEvent =
   | { type: "runtime"; sessionId: string; sessionFile: string; activitySessionFile?: string; action: "ensure" | "clear" | "changed" | "completed"; aborted?: boolean }
   | { type: "wire"; value: JsonValue };
 
-/**
- * Navigation has one serving-side finalizer. `finish` is intentionally not
- * serializable: a remote runner returns the data first and its serving adapter
- * finalizes only after writing that data to its own transport.
- */
 export type NavigationResult = {
   state: BaseSessionStateDto;
-  finish(): void;
   [key: string]: unknown;
 };
 

--- a/server/session/service.ts
+++ b/server/session/service.ts
@@ -85,12 +85,23 @@ export interface LocalSessionServiceDependencies {
   clientCount(): number;
 }
 
+type WorkLeaseKind = "general" | "retry";
+
+type WorkLeaseToken = { sessionKey: string; key: symbol };
+
+type WorkLease = {
+  id: number;
+  label: string;
+  kind: WorkLeaseKind;
+  acquiredAt: number;
+  watchdogTimer?: ReturnType<typeof setTimeout>;
+};
+
 type LiveSessionEntry = {
   session: PiWebSession;
   unsubscribe?: () => void;
   viewerClientIds: Set<string>;
-  workLeases: number;
-  retryLeases: number;
+  workLeases: Map<symbol, WorkLease>;
   disposeTimer?: ReturnType<typeof setTimeout>;
   disposing?: boolean;
 };
@@ -180,10 +191,12 @@ export class LocalSessionService implements SessionService {
   private readonly pendingPromptCorrelations = new Map<string, PendingPromptCorrelation[]>();
   private readonly knownSessionCwds = new Set<string>();
   private readonly protectedSessionIds = new Set<string>();
+  private nextWorkLeaseId = 1;
   readonly settingsStore = createSettingsStore(process.env.PI_WEB_SETTINGS_FILE || join(getAgentDir(), "pi-web-settings.json"));
   private readonly noSession = process.env.PI_WEB_NO_SESSION === "1";
   private readonly idleGraceMs = envMs("PI_WEB_SESSION_IDLE_GRACE_MS", 24 * 60 * 60 * 1000);
   private readonly viewerGraceMs = envMs("PI_WEB_VIEWER_LEASE_GRACE_MS", Math.min(30_000, this.idleGraceMs));
+  private readonly workLeaseWatchdogMs = envMs("PI_WEB_WORK_LEASE_WATCHDOG_MS", 3 * 60 * 1000);
   private readonly webUiBridge;
 
   constructor(private readonly deps: LocalSessionServiceDependencies) {
@@ -199,7 +212,7 @@ export class LocalSessionService implements SessionService {
         }
       },
       clientCount: deps.clientCount,
-      acquireWorkLease: (session) => this.acquireWorkLease(session),
+      withWorkLease: (session, label, operation) => this.withWorkLease(session, label, "general", operation),
       createNewSession: (cwd, previousSessionFile) => this.createNewLiveSession(cwd, previousSessionFile),
       sessionCwd: (session) => this.sessionCwd(session),
       state: (session) => this.projectState(session) as unknown as Record<string, unknown>,
@@ -249,8 +262,8 @@ export class LocalSessionService implements SessionService {
   }
 
   sessionForPath(path: string) { return this.liveSessions.get(path)?.session; }
-  hasActiveWorkForPath(path: string) { return (this.liveSessions.get(path)?.workLeases || 0) > 0; }
-  hasActiveRetryForPath(path: string) { return (this.liveSessions.get(path)?.retryLeases || 0) > 0; }
+  hasActiveWorkForPath(path: string) { return (this.liveSessions.get(path)?.workLeases.size || 0) > 0; }
+  hasActiveRetryForPath(path: string) { return Array.from(this.liveSessions.get(path)?.workLeases.values() || []).some((lease) => lease.kind === "retry"); }
   sessionForId(id: string) { return this.liveById.get(id); }
   cwdForSession(value: PiWebSession) { return this.sessionCwd(value); }
   async cwdForSessionId(id: string) {
@@ -372,7 +385,7 @@ export class LocalSessionService implements SessionService {
 
   async abort(sessionId: string) {
     const value = await this.require(sessionId);
-    void value.abort().catch((error) => this.emitError(value, error));
+    void this.abortSession(value);
     return { sessionId: value.sessionId };
   }
 
@@ -402,25 +415,12 @@ export class LocalSessionService implements SessionService {
     if (value.isStreaming) throw new SessionServiceError("Wait for the current response to finish before navigating the tree", 409);
     if (value.isCompacting) throw new SessionServiceError("Wait for the current compaction to finish before navigating the tree", 409);
     if (!value.navigateTree) throw new SessionServiceError("Tree navigation is not available");
-    const releaseWorkLease = this.acquireWorkLease(value);
-    let finished = false;
-    const finish = () => {
-      if (finished) return;
-      finished = true;
-      releaseWorkLease();
-      this.emitRuntime(value, "changed");
-    };
-    try {
-      const navigation = value.navigateTree(targetId, options as any);
-      this.emitRuntime(value, "changed");
-      const result = await navigation;
+    return this.withWorkLease(value, "navigate", "general", async () => {
+      const result = await value.navigateTree!(targetId, options as any);
       const state = this.projectState(value);
       this.emit({ type: "state", state, includeThinkingLevels: true });
-      return { ...jsonSafe(result as Record<string, JsonValue>), leafId: value.sessionManager.getLeafId?.() || null, state, finish };
-    } catch (error) {
-      finish();
-      throw error;
-    }
+      return { ...jsonSafe(result as Record<string, JsonValue>), leafId: value.sessionManager.getLeafId?.() || null, state };
+    });
   }
 
   invokeContribution(sessionId: string | undefined, input: Record<string, unknown>) {
@@ -603,7 +603,15 @@ export class LocalSessionService implements SessionService {
         sessionId: entry.session.sessionId,
         sessionFile: entry.session.sessionFile,
         viewerLeases: entry.viewerClientIds.size,
-        workLeases: entry.workLeases,
+        workLeases: entry.workLeases.size,
+        retryLeases: Array.from(entry.workLeases.values()).filter((lease) => lease.kind === "retry").length,
+        leases: Array.from(entry.workLeases.values()).map((lease) => ({
+          id: lease.id,
+          label: lease.label,
+          kind: lease.kind,
+          acquiredAt: new Date(lease.acquiredAt).toISOString(),
+          heldForMs: Math.max(0, Date.now() - lease.acquiredAt),
+        })),
         hasDisposeTimer: Boolean(entry.disposeTimer),
         isStreaming: Boolean(entry.session.isStreaming),
         isCompacting: Boolean(entry.session.isCompacting),
@@ -707,7 +715,7 @@ export class LocalSessionService implements SessionService {
     const key = sessionPathKey(value);
     if (!key || this.liveSessions.get(key)?.session === value) return value;
     const unsubscribe = value.subscribe?.((event) => this.handlePiEvent(value, event));
-    this.liveSessions.set(key, { session: value, unsubscribe, viewerClientIds: new Set(), workLeases: 0, retryLeases: 0 });
+    this.liveSessions.set(key, { session: value, unsubscribe, viewerClientIds: new Set(), workLeases: new Map() });
     this.liveById.set(value.sessionId, value);
     if (value.sessionFile) this.sessionLocations.set(value.sessionId, { path: resolve(value.sessionFile), cwd: resolve(this.sessionCwd(value)) });
     this.rememberSessionName(value);
@@ -811,26 +819,65 @@ export class LocalSessionService implements SessionService {
     else this.pendingPromptCorrelations.delete(sessionKey);
   }
 
-  private acquireWorkLease(value: PiWebSession, kind: "general" | "retry" = "general") {
+  private acquireWorkLease(value: PiWebSession, label: string, kind: WorkLeaseKind) {
     const key = sessionPathKey(value);
     const entry = this.liveSessions.get(key);
-    if (!entry) return () => undefined;
-    entry.workLeases++;
-    if (kind === "retry") entry.retryLeases++;
+    if (!entry) return undefined;
+    const token = Symbol(label);
+    const lease: WorkLease = { id: this.nextWorkLeaseId++, label, kind, acquiredAt: Date.now() };
+    if (this.workLeaseWatchdogMs > 0) {
+      lease.watchdogTimer = setTimeout(() => {
+        if (!entry.workLeases.has(token)) return;
+        console.warn("Session work lease watchdog: lease remains active", {
+          sessionId: value.sessionId, sessionFile: value.sessionFile, leaseId: lease.id,
+          label: lease.label, kind: lease.kind, acquiredAt: new Date(lease.acquiredAt).toISOString(),
+          heldForMs: Date.now() - lease.acquiredAt,
+        });
+      }, this.workLeaseWatchdogMs);
+      lease.watchdogTimer.unref?.();
+    }
+    entry.workLeases.set(token, lease);
     this.cancelLiveSessionCleanup(entry);
-    let released = false;
-    return () => {
-      if (released) return;
-      released = true;
-      entry.workLeases = Math.max(0, entry.workLeases - 1);
-      if (kind === "retry") entry.retryLeases = Math.max(0, entry.retryLeases - 1);
-      this.scheduleLiveSessionCleanup(key);
-    };
+    this.emitRuntime(value, "changed");
+    return { sessionKey: key, key: token } satisfies WorkLeaseToken;
+  }
+
+  private releaseWorkLease(value: PiWebSession, token: WorkLeaseToken | undefined) {
+    if (!token) return;
+    const entry = this.liveSessions.get(token.sessionKey);
+    const lease = entry?.workLeases.get(token.key);
+    if (!entry || !lease) return;
+    this.clearTimer(lease.watchdogTimer);
+    entry.workLeases.delete(token.key);
+    this.scheduleLiveSessionCleanup(token.sessionKey);
+    this.emitRuntime(value, "changed");
+  }
+
+  private async withWorkLease<T>(value: PiWebSession, label: string, kind: WorkLeaseKind, operation: () => T | Promise<T>): Promise<T> {
+    const token = this.acquireWorkLease(value, label, kind);
+    try { return await operation(); }
+    finally { this.releaseWorkLease(value, token); }
+  }
+
+  private clearWorkLeases(value: PiWebSession, reason: string) {
+    const located = Array.from(this.liveSessions.entries()).find(([, candidate]) => candidate.session === value);
+    const key = located?.[0] || sessionPathKey(value);
+    const entry = located?.[1] || this.liveSessions.get(key);
+    if (!entry?.workLeases.size) return;
+    const leases = Array.from(entry.workLeases.values());
+    for (const lease of leases) this.clearTimer(lease.watchdogTimer);
+    entry.workLeases.clear();
+    console.warn("Cleared session work leases", {
+      sessionId: value.sessionId, sessionFile: value.sessionFile, reason,
+      leases: leases.map(({ id, label, kind, acquiredAt }) => ({ id, label, kind, acquiredAt: new Date(acquiredAt).toISOString() })),
+    });
+    this.scheduleLiveSessionCleanup(key);
+    this.emitRuntime(value, "changed");
   }
 
   private clearTimer(timer?: ReturnType<typeof setTimeout>) { if (timer) clearTimeout(timer); }
   private cancelLiveSessionCleanup(entry: LiveSessionEntry) { this.clearTimer(entry.disposeTimer); entry.disposeTimer = undefined; }
-  private isLiveSessionBusy(entry: LiveSessionEntry) { return Boolean(entry.session.isStreaming || entry.session.isCompacting || entry.workLeases > 0); }
+  private isLiveSessionBusy(entry: LiveSessionEntry) { return Boolean(entry.session.isStreaming || entry.session.isCompacting || entry.workLeases.size > 0); }
   private shouldKeepLiveSession(entry: LiveSessionEntry) { return this.protectedSessionIds.has(entry.session.sessionId) || entry.viewerClientIds.size > 0 || this.isLiveSessionBusy(entry); }
 
   private scheduleLiveSessionCleanup(key: string) {
@@ -861,6 +908,8 @@ export class LocalSessionService implements SessionService {
     if (!entry || entry.disposing || (!force && this.shouldKeepLiveSession(entry))) return;
     entry.disposing = true;
     this.cancelLiveSessionCleanup(entry);
+    for (const lease of entry.workLeases.values()) this.clearTimer(lease.watchdogTimer);
+    entry.workLeases.clear();
     const value = entry.session;
     const sessionId = value.sessionId;
     const sessionFile = value.sessionFile || key;
@@ -1098,18 +1147,27 @@ export class LocalSessionService implements SessionService {
         if (value.isCompacting) throw new Error("Compaction is already running.");
         if (!value.compact) throw new Error("Compaction is not available in this session.");
         this.emitRuntime(value, "ensure");
-        const release = this.acquireWorkLease(value);
-        void value.compact(args || undefined).catch((error) => {
+        void this.withWorkLease(value, "compact", "general", () => value.compact!(args || undefined)).catch((error) => {
           this.emitRuntime(value, "clear");
           this.emitError(value, error);
-        }).finally(release);
+        });
         return { message: "Compaction started.", state: state() };
       }
       case "abort": case "stop":
-        await value.abort();
+        await this.abortSession(value);
         return { message: "Aborted.", state: state() };
       default: throw new Error(`Unknown slash command: /${name}. Try /help.`);
     }
+  }
+
+  private abortSession(value: PiWebSession) {
+    const wasSdkActive = Boolean(value.isStreaming || value.isCompacting);
+    const aborting = value.abort().catch((error) => this.emitError(value, error));
+    if (!wasSdkActive) this.clearWorkLeases(value, "abort while SDK idle");
+    else void aborting.then(() => {
+      if (!value.isStreaming && !value.isCompacting) this.clearWorkLeases(value, "active abort settled");
+    });
+    return aborting;
   }
 
   private async startSessionPrompt(value: PiWebSession, input: { message: string; mode: string; attachments: AttachmentDto[]; clientMessageId?: string; sourceClientId?: string }) {
@@ -1117,14 +1175,12 @@ export class LocalSessionService implements SessionService {
     if (!this.deps.sessionFactory?.isMock && input.clientMessageId && input.sourceClientId) this.rememberPromptCorrelation(sessionPathKey(value), { clientMessageId: input.clientMessageId, sourceClientId: input.sourceClientId, createdAt: Date.now() });
     if (!value.isStreaming && !value.isCompacting) this.emitRuntime(value, "ensure");
     const promptSessionFile = value.sessionFile;
-    const release = this.acquireWorkLease(value);
-    void value.prompt(promptText, {
+    void this.withWorkLease(value, "prompt", "general", () => value.prompt(promptText, {
       ...(value.isStreaming ? { streamingBehavior: input.mode } : {}),
-    }).catch((error) => {
+    })).catch((error) => {
       if (!this.deps.sessionFactory?.isMock && input.clientMessageId) this.forgetPromptCorrelation(sessionPathKey(value), input.clientMessageId);
       this.emitError(value, error, input.clientMessageId);
     }).finally(() => {
-      release();
       const lastMessage = Array.isArray(value.agent?.state?.messages) ? value.agent.state.messages.at(-1) : undefined;
       this.emitRuntime(value, "completed", promptSessionFile, isAssistantAbortedMessage(lastMessage));
     });
@@ -1196,14 +1252,10 @@ export class LocalSessionService implements SessionService {
     this.emitRuntime(value, "ensure");
     const retrySessionFile = value.sessionFile;
     const usesCompatibilityFallback = !value.retryFromFailure;
-    const release = this.acquireWorkLease(value, "retry");
-    void this.retryFromFailure(value).catch((error) => {
+    void this.withWorkLease(value, "retry", "retry", () => this.retryFromFailure(value)).catch((error) => {
       this.emitRuntime(value, "clear", retrySessionFile);
       this.emitError(value, error);
     }).finally(() => {
-      // The terminal projection must happen after releasing the lease, or it
-      // would report this completed continuation as still running.
-      release();
       // The private SDK fallback bypasses AgentSession._runAgentPrompt(), so it
       // cannot emit pi's authoritative idle event itself. Translate settlement
       // only after releasing the compatibility lease.

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -101,6 +101,9 @@ describe("pi-web mock API", () => {
     const sessions = await (await fetch(`${baseUrl}/api/sessions`)).json();
     expect(sessions.sessions).toHaveLength(2);
     expect(sessions.sessions.every((item: any) => item.isCurrent === false)).toBe(true);
+
+    const lifecycle = await (await fetch(`${baseUrl}/api/session/lifecycle`)).json();
+    expect(lifecycle).toMatchObject({ ok: true, liveSessions: [expect.objectContaining({ sessionId: "mock-current", leases: [] })] });
   });
 
   it("deletes a requested session", async () => {
@@ -756,9 +759,13 @@ describe("artifact serving", () => {
       // artifact accessible without token
       const artifactRes = await fetch(`${tokenBaseUrl}/api/artifacts/test.png`);
       expect(artifactRes.status).toBe(200);
-      // api route still requires token
+      // normal API routes, including diagnostics, still require the token
       const apiRes = await fetch(`${tokenBaseUrl}/api/state`);
       expect(apiRes.status).toBe(401);
+      expect((await fetch(`${tokenBaseUrl}/api/session/lifecycle`)).status).toBe(401);
+      const diagnostics = await fetch(`${tokenBaseUrl}/api/session/lifecycle`, { headers: { authorization: "Bearer secret" } });
+      expect(diagnostics.status).toBe(200);
+      expect(await diagnostics.json()).toMatchObject({ ok: true, liveSessions: expect.any(Array) });
     } finally {
       tokenChild.kill();
     }

--- a/tests/extensions.test.ts
+++ b/tests/extensions.test.ts
@@ -91,7 +91,7 @@ describe("bundled extension path discovery", () => {
     let ui: any;
     const emitted: any[] = [];
     const bridge = createWebUiBridge({
-      emit: (value) => emitted.push(value), clientCount: () => 1, acquireWorkLease: () => () => undefined,
+      emit: (value) => emitted.push(value), clientCount: () => 1, withWorkLease: (_session: any, _label: string, operation: () => Promise<any>) => operation(),
       createNewSession: async () => ({}), sessionCwd: () => process.cwd(), state: () => ({}),
     });
     const session = {
@@ -132,7 +132,7 @@ describe("bundled extension path discovery", () => {
     let ui: any;
     const emitted: any[] = [];
     const bridge = createWebUiBridge({
-      emit: (value) => emitted.push(value), clientCount: () => 1, acquireWorkLease: () => () => undefined,
+      emit: (value) => emitted.push(value), clientCount: () => 1, withWorkLease: (_session: any, _label: string, operation: () => Promise<any>) => operation(),
       createNewSession: async () => ({}), sessionCwd: () => process.cwd(), state: () => ({}),
     });
     const session = {
@@ -175,7 +175,7 @@ describe("bundled extension path discovery", () => {
     let ui: any;
     const emitted: any[] = [];
     const bridge = createWebUiBridge({
-      emit: (value) => emitted.push(value), clientCount: () => 1, acquireWorkLease: () => () => undefined,
+      emit: (value) => emitted.push(value), clientCount: () => 1, withWorkLease: (_session: any, _label: string, operation: () => Promise<any>) => operation(),
       createNewSession: async () => ({}), sessionCwd: () => process.cwd(), state: () => ({}),
     });
     await bridge.bind({
@@ -207,7 +207,7 @@ describe("bundled extension path discovery", () => {
     let bindOptions: any;
     const emitted: any[] = [];
     const bridge = createWebUiBridge({
-      emit: (value) => emitted.push(value), clientCount: () => 1, acquireWorkLease: () => () => undefined,
+      emit: (value) => emitted.push(value), clientCount: () => 1, withWorkLease: (_session: any, _label: string, operation: () => Promise<any>) => operation(),
       createNewSession: async () => ({}), sessionCwd: () => process.cwd(), state: () => ({}),
     });
     const session = {
@@ -267,7 +267,7 @@ describe("bundled extension path discovery", () => {
     let ui: any;
     const emitted: any[] = [];
     const bridge = createWebUiBridge({
-      emit: (value) => emitted.push(value), clientCount: () => 1, acquireWorkLease: () => () => undefined,
+      emit: (value) => emitted.push(value), clientCount: () => 1, withWorkLease: (_session: any, _label: string, operation: () => Promise<any>) => operation(),
       createNewSession: async () => ({}), sessionCwd: () => process.cwd(), state: () => ({}),
     } as any);
     const session = {

--- a/tests/session-service.test.ts
+++ b/tests/session-service.test.ts
@@ -162,12 +162,12 @@ describe("LocalSessionService contract", () => {
     for (const event of events) expect(jsonRoundTrip(event)).toStrictEqual(event);
   });
 
-  it("keeps navigation data serializable and its finalizer serving-side", async () => {
+  it("returns serializable navigation data after releasing its lease", async () => {
     const { service, initial } = await fixtureService();
-    const { finish, ...result } = await service.navigate(initial.sessionId, "result", {});
+    const result = await service.navigate(initial.sessionId, "result", {});
     expect(jsonRoundTrip(result)).toStrictEqual(result);
-    expect(finish).toEqual(expect.any(Function));
-    finish();
+    expect(service.hasActiveWorkForPath(initial.sessionFile)).toBe(false);
+    expect(result).not.toHaveProperty("finish");
   });
 
   it("maps unavailable conversation trees to the legacy 400 status", async () => {
@@ -252,7 +252,7 @@ describe("LocalSessionService contract", () => {
 
   it("keeps the dependency surface to six true externals", async () => {
     const source = await readFile(new URL("../server/session/service.ts", import.meta.url), "utf8");
-    const body = source.slice(source.indexOf("export interface LocalSessionServiceDependencies"), source.indexOf("}\n\ntype LiveSessionEntry"));
+    const body = source.slice(source.indexOf("export interface LocalSessionServiceDependencies"), source.indexOf("}\n\ntype WorkLeaseKind"));
     expect(body.match(/^  \w+[^\n]*;/gm)).toHaveLength(6);
     expect(body).not.toContain("decorateState");
     expect(body).not.toContain("resolve(sessionId");
@@ -324,8 +324,12 @@ describe("LocalSessionService contract", () => {
       request: { source: "extension", kind: "confirm", payload: { title: "Allow?", message: "Run tool" }, timeout: 1_000 },
     });
     if (!interaction || interaction.type !== "interaction") throw new Error("Missing interaction request");
+    expect(service.lifecycleSnapshot().liveSessions[0]?.leases).toEqual([
+      expect.objectContaining({ label: "extension-interaction:confirm", kind: "general" }),
+    ]);
     expect(service.respondInteraction({ id: interaction.request.id, confirmed: true })).toBe(true);
     await expect(answer).resolves.toBe(true);
+    expect(service.lifecycleSnapshot().liveSessions[0]?.leases).toEqual([]);
   });
 
   it("denies timed-out and disconnected interactions through the service boundary", async () => {
@@ -510,12 +514,60 @@ describe("LocalSessionService standalone lifecycle", () => {
     expect(service.sessionForId(viewed.sessionId)).toBeUndefined();
 
     const working = await service.create(undefined);
-    const navigation = await service.navigate(working.sessionId, "result", {});
-    await vi.advanceTimersByTimeAsync(100);
+    await service.navigate(working.sessionId, "result", {});
+    await vi.advanceTimersByTimeAsync(29);
     expect(service.sessionForId(working.sessionId)).toBeDefined();
-    navigation.finish();
-    await vi.advanceTimersByTimeAsync(30);
+    await vi.advanceTimersByTimeAsync(1);
     expect(service.sessionForId(working.sessionId)).toBeUndefined();
+  });
+
+  it("exposes per-lease diagnostics and warns without expiring long work", async () => {
+    vi.stubEnv("PI_WEB_WORK_LEASE_WATCHDOG_MS", "20");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { service, initial } = await fixtureService();
+    let finishNavigate!: () => void;
+    let markEntered!: () => void;
+    const entered = new Promise<void>((resolve) => { markEntered = resolve; });
+    initial.navigateTree = () => { markEntered(); return new Promise((resolve) => { finishNavigate = () => resolve({ cancelled: false }); }); };
+    vi.useFakeTimers();
+
+    const navigation = service.navigate(initial.sessionId, "result", {});
+    await entered;
+    expect(service.lifecycleSnapshot().liveSessions[0]).toMatchObject({
+      workLeases: 1,
+      retryLeases: 0,
+      leases: [{ label: "navigate", kind: "general", heldForMs: 0 }],
+    });
+    await vi.advanceTimersByTimeAsync(20);
+    expect(warn).toHaveBeenCalledWith("Session work lease watchdog: lease remains active", expect.objectContaining({ label: "navigate", heldForMs: 20 }));
+    expect(service.hasActiveWorkForPath(initial.sessionFile)).toBe(true);
+
+    finishNavigate();
+    await navigation;
+    expect(service.lifecycleSnapshot().liveSessions[0]?.leases).toEqual([]);
+    warn.mockRestore();
+  });
+
+  it("lets abort recover a gated lease and ignores its late scoped release", async () => {
+    const { service, initial } = await fixtureService();
+    let finishNavigate!: () => void;
+    let markEntered!: () => void;
+    const entered = new Promise<void>((resolve) => { markEntered = resolve; });
+    initial.navigateTree = () => { markEntered(); return new Promise((resolve) => { finishNavigate = () => resolve({ cancelled: false }); }); };
+    const events: SessionServiceEvent[] = [];
+    service.subscribe((event) => events.push(event));
+
+    const navigation = service.navigate(initial.sessionId, "result", {});
+    await entered;
+    expect(service.hasActiveWorkForPath(initial.sessionFile)).toBe(true);
+    await service.abort(initial.sessionId);
+    expect(service.hasActiveWorkForPath(initial.sessionFile)).toBe(false);
+    const changedAfterAbort = events.filter((event) => event.type === "runtime" && event.action === "changed").length;
+
+    finishNavigate();
+    await navigation;
+    expect(service.hasActiveWorkForPath(initial.sessionFile)).toBe(false);
+    expect(events.filter((event) => event.type === "runtime" && event.action === "changed")).toHaveLength(changedAfterAbort);
   });
 
   it("does not let a stale socket release a replacement viewer lease", async () => {
@@ -612,12 +664,14 @@ describe("session route boundary", () => {
     expect(routes).not.toContain("targetSession.");
   });
 
-  it("writes a navigation response before calling its serving-side finalizer", async () => {
+  it("keeps navigation lease finalization inside the service and exposes lifecycle diagnostics", async () => {
     const source = await readFile(new URL("../server.ts", import.meta.url), "utf8");
     const start = source.indexOf('url.pathname === "/api/session/tree/navigate"');
     const route = source.slice(start, source.indexOf('url.pathname === "/api/session/tree/abort-summary"', start));
-    expect(route.indexOf("sendJson(res, 200")).toBeGreaterThan(-1);
-    expect(route.indexOf("sendJson(res, 200")).toBeLessThan(route.indexOf("finish();"));
+    expect(route).toContain("sessionService.navigate");
+    expect(route).not.toContain("finish");
+    expect(source).toContain('url.pathname === "/api/session/lifecycle"');
+    expect(source).toContain("sessionService.lifecycleSnapshot()");
     expect(route).not.toContain("setTimeout");
   });
 });

--- a/tests/web-ui-settings.test.ts
+++ b/tests/web-ui-settings.test.ts
@@ -34,7 +34,7 @@ async function makeBridge() {
   const bridge = createWebUiBridge({
     emit: (value) => emitted.push(value),
     clientCount: () => 1,
-    acquireWorkLease: () => () => undefined,
+    withWorkLease: (_session: any, _label: string, operation: () => Promise<any>) => operation(),
     createNewSession: async () => ({}),
     sessionCwd: () => "/repo",
     state: () => ({}),


### PR DESCRIPTION
## Summary
- replace manual work-lease counters and release closures with scoped, tokenized leases
- let abort, `/abort`, and `/stop` recover sessions wedged by stale leases
- add lease watchdog logging and authenticated lifecycle diagnostics
- keep navigation lease ownership inside the session service
- add regression coverage for recovery, settlement, diagnostics, and extension interactions

## Validation
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npx vitest run tests/session-service.test.ts tests/api.test.ts tests/extensions.test.ts tests/web-ui-settings.test.ts`
- `git diff --check`

Closes #105