### PR TITLE
Isolate Pi projection and retry internals

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -232,7 +232,7 @@ function applySessionUnreadState<T extends { id: string }>(sessions: T[], sessio
 }
 
 function decorateState(baseState: BaseSessionStateDto, targetSession: PiWebSession, includeThinkingLevels = false): WireSessionState {
-  const state = decorateHostSessionState(baseState, targetSession, sessionActivity, (value) => sessionService.webUiEntries(value), includeThinkingLevels);
+  const state = decorateHostSessionState(baseState, sessionService.activityView(targetSession), sessionActivity, sessionService.webUiEntries(targetSession), includeThinkingLevels);
   return (mockMode ? { ...state, ...mockStateOverrides } : state) as WireSessionState;
 }
 
@@ -268,7 +268,7 @@ const pushNotifications = createPushNotificationService(
 );
 let sessionService: LocalSessionService;
 const sessionActivity = new SessionActivity(
-  (path) => sessionService?.sessionForPath(path),
+  (path) => sessionService?.activityViewForPath(path),
   (path) => sessionService?.hasActiveWorkForPath(path) ?? false,
   (path) => sessionService?.hasActiveRetryForPath(path) ?? false,
 );
@@ -386,9 +386,9 @@ async function applyDefaultSessionBucket(sessionId: string) {
 }
 
 const handleSessionServiceEvent = createHostSessionEventHandler({
-  sessionForId: (id) => sessionService.sessionForId(id),
-  projectState: (value) => sessionService.projectState(value),
-  webUiEntries: (value) => sessionService.webUiEntries(value),
+  sessionViewForId: (id) => sessionService.activityViewForId(id),
+  projectStateForId: (id) => sessionService.projectStateForId(id),
+  webUiEntriesForId: (id) => sessionService.webUiEntriesForId(id),
   sessionActivity,
   broadcast,
   markSessionUnreadCompleted,

--- a/server/mock.ts
+++ b/server/mock.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import type { PiWebSession, PiWebSessionInfo } from "./types.js";
-import { simplifyMessage } from "./session/projection.js";
+import { simplifyMessage } from "./session/pi/projection.js";
 import { mapPiEvent } from "./session/piEventMap.js";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import websiteWorkflowExtension from "./fixtures/websiteWorkflowExtension.js";

--- a/server/session/activity.ts
+++ b/server/session/activity.ts
@@ -1,5 +1,5 @@
 import type { PiWebSession } from "../types.js";
-import { sessionIsRetrying, simplifyModel } from "./projection.js";
+import { sessionIsRetrying, simplifyModel } from "./pi/projection.js";
 
 export interface EnrichedSessionEvent {
   event: any;

--- a/server/session/activity.ts
+++ b/server/session/activity.ts
@@ -1,8 +1,21 @@
-import type { PiWebSession } from "../types.js";
-import { sessionIsRetrying, simplifyModel } from "./pi/projection.js";
+import type { HarnessEventDto } from "./piEventMap.js";
+import type { ModelDto } from "./dto.js";
+
+/** Host-facing snapshot of a live session. It deliberately contains no harness object. */
+export interface SessionActivityView {
+  sessionId: string;
+  sessionFile: string;
+  isStreaming: boolean;
+  isRetrying: boolean;
+  isCompacting: boolean;
+  pendingMessageCount: number;
+  model?: ModelDto;
+  runtimeStartedAt?: string;
+  runtimeLastActivityAt?: string;
+}
 
 export interface EnrichedSessionEvent {
-  event: any;
+  event: HarnessEventDto;
   sessionId: string;
   sessionFile: string;
 }
@@ -13,13 +26,13 @@ export class SessionActivity {
   private readonly toolStartedAts = new Map<string, Map<string, string>>();
 
   constructor(
-    private readonly liveSessionForPath: (path: string) => PiWebSession | undefined,
+    private readonly liveSessionForPath: (path: string) => SessionActivityView | undefined,
     private readonly hasActiveWorkForPath: (path: string) => boolean = () => false,
     private readonly hasActiveRetryForPath: (path: string) => boolean = () => false,
   ) {}
 
-  sessionPathKey(value: any): string {
-    return String(value?.sessionFile || value?.sessionId || "");
+  sessionPathKey(value: Pick<SessionActivityView, "sessionFile" | "sessionId">): string {
+    return String(value.sessionFile || value.sessionId || "");
   }
 
   toolRuntimeKey(toolCallId: unknown, toolName: unknown): string {
@@ -44,61 +57,49 @@ export class SessionActivity {
     });
   }
 
-  hasStarted(path: string): boolean {
-    return this.runtimeStartedAts.has(path);
-  }
+  hasStarted(path: string): boolean { return this.runtimeStartedAts.has(path); }
 
   startedAtForPath(path: string, isRunning: boolean): string | undefined {
     if (!isRunning) return undefined;
-    const liveStartedAt = (this.liveSessionForPath(path) as any)?.runtimeStartedAt;
-    return typeof liveStartedAt === "string" && liveStartedAt.trim() ? liveStartedAt : this.runtimeStartedAts.get(path);
+    const live = this.liveSessionForPath(path)?.runtimeStartedAt;
+    return typeof live === "string" && live.trim() ? live : this.runtimeStartedAts.get(path);
   }
 
   lastActivityAtForPath(path: string, isRunning: boolean): string | undefined {
     if (!isRunning) return undefined;
-    const liveLastActivityAt = (this.liveSessionForPath(path) as any)?.runtimeLastActivityAt;
-    return typeof liveLastActivityAt === "string" && liveLastActivityAt.trim()
-      ? liveLastActivityAt
+    const live = this.liveSessionForPath(path)?.runtimeLastActivityAt;
+    return typeof live === "string" && live.trim()
+      ? live
       : this.runtimeLastActivityAts.get(path) || this.startedAtForPath(path, isRunning);
   }
 
-  ensureStarted(targetSession: any, startedAt = new Date().toISOString()): string {
-    const key = this.sessionPathKey(targetSession);
-    const existing = key ? this.runtimeStartedAts.get(key) : undefined;
-    const value = typeof targetSession?.runtimeStartedAt === "string" ? targetSession.runtimeStartedAt : existing || startedAt;
+  ensureStarted(target: Pick<SessionActivityView, "sessionFile" | "sessionId" | "runtimeStartedAt" | "runtimeLastActivityAt">, startedAt = new Date().toISOString()): string {
+    const key = this.sessionPathKey(target);
+    const value = target.runtimeStartedAt || (key ? this.runtimeStartedAts.get(key) : undefined) || startedAt;
     if (key) {
       this.runtimeStartedAts.set(key, value);
-      if (!this.runtimeLastActivityAts.has(key)) this.runtimeLastActivityAts.set(key, value);
-    }
-    if (targetSession && typeof targetSession === "object") {
-      targetSession.runtimeStartedAt = value;
-      if (typeof targetSession.runtimeLastActivityAt !== "string") targetSession.runtimeLastActivityAt = value;
+      if (!this.runtimeLastActivityAts.has(key)) this.runtimeLastActivityAts.set(key, target.runtimeLastActivityAt || value);
     }
     return value;
   }
 
-  mark(targetSession: any, activityAt = new Date().toISOString(), sessionFile = this.sessionPathKey(targetSession)): string {
+  mark(_target: Pick<SessionActivityView, "sessionFile" | "sessionId">, activityAt = new Date().toISOString(), sessionFile = this.sessionPathKey(_target)): string {
     if (sessionFile) this.runtimeLastActivityAts.set(sessionFile, activityAt);
-    if (targetSession && typeof targetSession === "object") targetSession.runtimeLastActivityAt = activityAt;
     return activityAt;
   }
 
-  clearStarted(targetSession: any, sessionFile = this.sessionPathKey(targetSession)): void {
+  clearStarted(_target: Pick<SessionActivityView, "sessionFile" | "sessionId">, sessionFile = this.sessionPathKey(_target)): void {
     if (sessionFile) {
       this.runtimeStartedAts.delete(sessionFile);
       this.runtimeLastActivityAts.delete(sessionFile);
     }
-    if (targetSession && typeof targetSession === "object") {
-      delete targetSession.runtimeStartedAt;
-      delete targetSession.runtimeLastActivityAt;
-    }
   }
 
-  clearSession(key: string, value: any): void {
+  clearSession(key: string, value: { sessionFile?: string }): void {
     this.runtimeStartedAts.delete(key);
     this.runtimeLastActivityAts.delete(key);
     this.toolStartedAts.delete(key);
-    const file = typeof value?.sessionFile === "string" ? value.sessionFile : "";
+    const file = typeof value.sessionFile === "string" ? value.sessionFile : "";
     if (file && file !== key) {
       this.runtimeStartedAts.delete(file);
       this.runtimeLastActivityAts.delete(file);
@@ -109,112 +110,79 @@ export class SessionActivity {
   runtimeForPath(path: string, overrides: { isRetrying?: boolean } = {}) {
     const live = this.liveSessionForPath(path);
     const isStreaming = Boolean(live?.isStreaming);
-    const isRetrying = overrides.isRetrying ?? sessionIsRetrying(live);
+    const isRetrying = overrides.isRetrying ?? Boolean(live?.isRetrying);
     const isCompacting = Boolean(live?.isCompacting);
-    // Work leases cover operations (notably the SDK continuation fallback) that
-    // execute an agent run without updating AgentSession.isStreaming.
     const isRunning = isStreaming || isRetrying || isCompacting || this.hasActiveWorkForPath(path);
     return {
-      loaded: Boolean(live),
-      isRunning,
-      isStreaming,
-      isRetrying,
-      isCompacting,
+      loaded: Boolean(live), isRunning, isStreaming, isRetrying, isCompacting,
       startedAt: this.startedAtForPath(path, isRunning),
       lastActivityAt: this.lastActivityAtForPath(path, isRunning),
       pendingMessageCount: Number(live?.pendingMessageCount || 0),
-      model: simplifyModel(live?.model),
+      model: live?.model,
     };
   }
 
   stoppedRuntimeForPath(path: string) {
     const live = this.liveSessionForPath(path);
     return {
-      loaded: Boolean(live),
-      isRunning: false,
-      isStreaming: false,
-      isRetrying: false,
-      isCompacting: false,
-      startedAt: undefined,
-      lastActivityAt: undefined,
-      pendingMessageCount: Number(live?.pendingMessageCount || 0),
-      model: simplifyModel(live?.model),
+      loaded: Boolean(live), isRunning: false, isStreaming: false, isRetrying: false, isCompacting: false,
+      startedAt: undefined, lastActivityAt: undefined,
+      pendingMessageCount: Number(live?.pendingMessageCount || 0), model: live?.model,
     };
   }
 
-  runtimeForEvent(path: string, event: any) {
-    if ((event?.type === "agent_end" || event?.type === "compaction_end") && event?.willRetry) {
-      return this.runtimeForPath(path, { isRetrying: true });
-    }
-    if (event?.type === "agent_settled") {
-      // pi emits this only after the run and all post-run continuations finish.
-      return this.hasActiveRetryForPath(path) ? this.runtimeForPath(path) : this.stoppedRuntimeForPath(path);
-    }
+  runtimeForEvent(path: string, event: HarnessEventDto) {
+    if ((event.type === "agent_end" || event.type === "compaction_end") && event.willRetry) return this.runtimeForPath(path, { isRetrying: true });
+    if (event.type === "agent_settled") return this.hasActiveRetryForPath(path) ? this.runtimeForPath(path) : this.stoppedRuntimeForPath(path);
     return this.runtimeForPath(path);
   }
 
-  isActivityEvent(event: any): boolean {
-    return ["agent_start", "compaction_start", "message_update", "message_end", "turn_end", "tool_execution_start", "tool_execution_update", "tool_execution_end", "auto_retry_start", "auto_retry_end"].includes(event?.type);
+  isActivityEvent(event: HarnessEventDto): boolean {
+    return ["agent_start", "compaction_start", "message_update", "message_end", "turn_end", "tool_execution_start", "tool_execution_update", "tool_execution_end", "auto_retry_start", "auto_retry_end"].includes(event.type);
   }
 
-  activityTimestamp(event: any, fallback = new Date().toISOString()): string {
-    for (const value of [event?.lastActivityAt, event?.timestamp, event?.startedAt]) {
-      if (typeof value === "string" && value.trim()) return value.trim();
-    }
+  activityTimestamp(event: HarnessEventDto, fallback = new Date().toISOString()): string {
+    const value = event as Record<string, unknown>;
+    for (const candidate of [value.lastActivityAt, value.timestamp, value.startedAt]) if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
     return fallback;
   }
 
-  noteEvent(sessionFile: string, event: any): void {
+  noteEvent(sessionFile: string, event: HarnessEventDto): void {
     if (!sessionFile) return;
-    switch (event?.type) {
-      case "agent_start":
-      case "compaction_start": {
-        const startedAt = typeof event.startedAt === "string" && event.startedAt.trim() ? event.startedAt.trim() : new Date().toISOString();
-        this.runtimeStartedAts.set(sessionFile, startedAt);
-        this.runtimeLastActivityAts.set(sessionFile, this.activityTimestamp(event, startedAt));
-        return;
-      }
-      case "agent_settled":
-      case "compaction_end":
-        if (!event.willRetry) {
-          this.runtimeStartedAts.delete(sessionFile);
-          this.runtimeLastActivityAts.delete(sessionFile);
-        }
-        return;
-      default:
-        if (this.isActivityEvent(event)) this.runtimeLastActivityAts.set(sessionFile, this.activityTimestamp(event));
-    }
+    if (event.type === "agent_start" || event.type === "compaction_start") {
+      const raw = event as Record<string, unknown>;
+      const startedAt = typeof raw.startedAt === "string" && raw.startedAt.trim() ? raw.startedAt.trim() : new Date().toISOString();
+      this.runtimeStartedAts.set(sessionFile, startedAt);
+      this.runtimeLastActivityAts.set(sessionFile, this.activityTimestamp(event, startedAt));
+    } else if (event.type === "agent_settled" || event.type === "compaction_end") {
+      if (event.type === "agent_settled" || !event.willRetry) { this.runtimeStartedAts.delete(sessionFile); this.runtimeLastActivityAts.delete(sessionFile); }
+    } else if (this.isActivityEvent(event)) this.runtimeLastActivityAts.set(sessionFile, this.activityTimestamp(event));
   }
 
-  enrichEvent(targetSession: PiWebSession, event: unknown): EnrichedSessionEvent {
-    const e = event as any;
-    const sessionFile = targetSession.sessionFile;
-    let eventForClient = e;
-    if (e?.type === "agent_start" || e?.type === "compaction_start") {
-      eventForClient = { ...e, startedAt: this.ensureStarted(targetSession, typeof e.startedAt === "string" ? e.startedAt : undefined) };
-    } else if ((e?.type === "agent_settled" || e?.type === "compaction_end") && !e.willRetry) {
-      this.clearStarted(targetSession, sessionFile);
-    }
+  enrichEvent(target: SessionActivityView, event: HarnessEventDto): EnrichedSessionEvent {
+    const sessionFile = target.sessionFile;
+    const raw = event as Record<string, unknown>;
+    let eventForClient: HarnessEventDto = event;
+    if (event.type === "agent_start" || event.type === "compaction_start") {
+      eventForClient = { ...event, startedAt: this.ensureStarted(target, typeof raw.startedAt === "string" ? raw.startedAt : undefined) } as HarnessEventDto;
+    } else if (event.type === "agent_settled" || event.type === "compaction_end" && !event.willRetry) this.clearStarted(target, sessionFile);
 
-    if (e?.type === "tool_execution_start") {
-      const toolKey = this.toolRuntimeKey(e.toolCallId, e.toolName);
-      const startedAt = typeof e.startedAt === "string" ? e.startedAt : new Date().toISOString();
+    if (event.type === "tool_execution_start") {
+      const toolKey = this.toolRuntimeKey(raw.toolCallId, raw.toolName);
+      const startedAt = typeof raw.startedAt === "string" ? raw.startedAt : new Date().toISOString();
       if (toolKey) {
         let starts = this.toolStartedAts.get(sessionFile);
         if (!starts) this.toolStartedAts.set(sessionFile, starts = new Map());
         starts.set(toolKey, startedAt);
       }
-      eventForClient = { ...eventForClient, startedAt };
-    } else if (e?.type === "tool_execution_update" || e?.type === "tool_execution_end") {
-      const toolKey = this.toolRuntimeKey(e.toolCallId, e.toolName);
+      eventForClient = { ...eventForClient, startedAt } as HarnessEventDto;
+    } else if (event.type === "tool_execution_update" || event.type === "tool_execution_end") {
+      const toolKey = this.toolRuntimeKey(raw.toolCallId, raw.toolName);
       const startedAt = toolKey ? this.toolStartedAts.get(sessionFile)?.get(toolKey) : undefined;
-      if (startedAt) eventForClient = { ...eventForClient, startedAt };
-      if (e?.type === "tool_execution_end" && toolKey) this.toolStartedAts.get(sessionFile)?.delete(toolKey);
+      if (startedAt) eventForClient = { ...eventForClient, startedAt } as HarnessEventDto;
+      if (event.type === "tool_execution_end" && toolKey) this.toolStartedAts.get(sessionFile)?.delete(toolKey);
     }
-
-    if (this.isActivityEvent(e)) {
-      eventForClient = { ...eventForClient, lastActivityAt: this.mark(targetSession, this.activityTimestamp(eventForClient), sessionFile) };
-    }
-    return { event: eventForClient, sessionId: targetSession.sessionId, sessionFile };
+    if (this.isActivityEvent(event)) eventForClient = { ...eventForClient, lastActivityAt: this.mark(target, this.activityTimestamp(eventForClient), sessionFile) } as HarnessEventDto;
+    return { event: eventForClient, sessionId: target.sessionId, sessionFile };
   }
 }

--- a/server/session/hostEvents.ts
+++ b/server/session/hostEvents.ts
@@ -1,5 +1,4 @@
-import type { PiWebSession } from "../types.js";
-import { SessionActivity } from "./activity.js";
+import { SessionActivity, type SessionActivityView } from "./activity.js";
 import type { BaseSessionStateDto, MessageDto, SessionServiceEvent } from "./dto.js";
 
 export type HostSessionStateDecoration = {
@@ -12,9 +11,9 @@ export type DecoratedSessionState = BaseSessionStateDto & HostSessionStateDecora
 export type WireSessionState = Omit<DecoratedSessionState, "thinkingLevels"> & { thinkingLevels?: string[] };
 
 type HostEventDependencies = {
-  sessionForId(sessionId: string): PiWebSession | undefined;
-  projectState(session: PiWebSession): BaseSessionStateDto;
-  webUiEntries(session: PiWebSession): Pick<HostSessionStateDecoration, "webContributions">;
+  sessionViewForId(sessionId: string): SessionActivityView | undefined;
+  projectStateForId(sessionId: string): BaseSessionStateDto | undefined;
+  webUiEntriesForId(sessionId: string): Pick<HostSessionStateDecoration, "webContributions"> | undefined;
   sessionActivity: SessionActivity;
   broadcast(value: unknown): void;
   markSessionUnreadCompleted(sessionId: string): void;
@@ -23,23 +22,19 @@ type HostEventDependencies = {
 
 export function decorateHostSessionState(
   baseState: BaseSessionStateDto,
-  targetSession: PiWebSession,
+  targetSession: SessionActivityView,
   sessionActivity: SessionActivity,
-  webUiEntries: HostEventDependencies["webUiEntries"],
+  webUiEntries: Pick<HostSessionStateDecoration, "webContributions">,
   includeThinkingLevels = false,
 ): WireSessionState {
   const { thinkingLevels, ...base } = baseState;
   const isRunning = Boolean(base.isStreaming || base.isRetrying || base.isCompacting);
   return {
     ...base,
-    runtimeStartedAt: typeof (targetSession as any).runtimeStartedAt === "string"
-      ? (targetSession as any).runtimeStartedAt
-      : sessionActivity.startedAtForPath(targetSession.sessionFile, isRunning),
-    runtimeLastActivityAt: typeof (targetSession as any).runtimeLastActivityAt === "string"
-      ? (targetSession as any).runtimeLastActivityAt
-      : sessionActivity.lastActivityAtForPath(targetSession.sessionFile, isRunning),
+    runtimeStartedAt: targetSession.runtimeStartedAt || sessionActivity.startedAtForPath(targetSession.sessionFile, isRunning),
+    runtimeLastActivityAt: targetSession.runtimeLastActivityAt || sessionActivity.lastActivityAtForPath(targetSession.sessionFile, isRunning),
     runtime: sessionActivity.runtimeForPath(targetSession.sessionFile),
-    ...webUiEntries(targetSession),
+    ...webUiEntries,
     ...(includeThinkingLevels ? { thinkingLevels } : {}),
   };
 }
@@ -68,13 +63,13 @@ export function decorateHostMessages(messages: MessageDto[], sessionFile: string
 
 /** Synchronous serving-layer adapter from service events to browser wire events. */
 export function createHostSessionEventHandler(deps: HostEventDependencies) {
-  const decorate = (state: BaseSessionStateDto, target: PiWebSession, includeThinkingLevels = false) =>
-    decorateHostSessionState(state, target, deps.sessionActivity, deps.webUiEntries, includeThinkingLevels);
+  const decorate = (state: BaseSessionStateDto, target: SessionActivityView, includeThinkingLevels = false) =>
+    decorateHostSessionState(state, target, deps.sessionActivity, deps.webUiEntriesForId(target.sessionId) || { webContributions: [] }, includeThinkingLevels);
 
   return (serviceEvent: SessionServiceEvent): void => {
     switch (serviceEvent.type) {
       case "agent": {
-        const target = deps.sessionForId(serviceEvent.sessionId);
+        const target = deps.sessionViewForId(serviceEvent.sessionId);
         const enriched = target
           ? deps.sessionActivity.enrichEvent(target, serviceEvent.event)
           : { event: serviceEvent.event, sessionId: serviceEvent.sessionId, sessionFile: serviceEvent.sessionFile };
@@ -116,7 +111,7 @@ export function createHostSessionEventHandler(deps: HostEventDependencies) {
         });
         return;
       case "state": {
-        const target = deps.sessionForId(serviceEvent.state.sessionId);
+        const target = deps.sessionViewForId(serviceEvent.state.sessionId);
         if (target) deps.broadcast({ type: "state_changed", ...decorate(serviceEvent.state, target, Boolean(serviceEvent.includeThinkingLevels)) });
         return;
       }
@@ -130,7 +125,7 @@ export function createHostSessionEventHandler(deps: HostEventDependencies) {
         deps.broadcast({ type: "server_error", ...(serviceEvent.sessionId ? { sessionId: serviceEvent.sessionId } : {}), ...(serviceEvent.sessionFile ? { sessionFile: serviceEvent.sessionFile } : {}), error: serviceEvent.error });
         return;
       case "runtime": {
-        const target = deps.sessionForId(serviceEvent.sessionId);
+        const target = deps.sessionViewForId(serviceEvent.sessionId);
         if (!target) return;
         const activitySessionFile = serviceEvent.activitySessionFile || serviceEvent.sessionFile;
         if (serviceEvent.action === "ensure") {
@@ -161,8 +156,11 @@ export function createHostSessionEventHandler(deps: HostEventDependencies) {
       case "wire": {
         const value = serviceEvent.value as any;
         if (value?.type === "state_changed" && typeof value.sessionId === "string") {
-          const target = deps.sessionForId(value.sessionId);
-          if (target) return deps.broadcast({ type: "state_changed", ...decorate(deps.projectState(target), target, true) });
+          const target = deps.sessionViewForId(value.sessionId);
+          if (target) {
+            const state = deps.projectStateForId(value.sessionId);
+            if (state) return deps.broadcast({ type: "state_changed", ...decorate(state, target, true) });
+          }
         }
         deps.broadcast(value);
       }
@@ -171,10 +169,10 @@ export function createHostSessionEventHandler(deps: HostEventDependencies) {
 }
 
 /** Unknown IDs may use the legacy current-session fallback; open failures must propagate. */
-export async function resolveWebSocketHelloSession(
+export async function resolveWebSocketHelloSession<T extends { sessionId: string }>(
   requestedSessionId: string,
-  currentSession: PiWebSession,
-  findSession: (sessionId: string) => Promise<PiWebSession | undefined>,
-): Promise<PiWebSession | undefined> {
+  currentSession: T,
+  findSession: (sessionId: string) => Promise<T | undefined>,
+): Promise<T | undefined> {
   return requestedSessionId === currentSession.sessionId ? currentSession : findSession(requestedSessionId);
 }

--- a/server/session/pi/projection.ts
+++ b/server/session/pi/projection.ts
@@ -1,6 +1,6 @@
-import { parseAttachmentMarkup } from "../shared/attachments.js";
-import type { PiWebSession } from "../types.js";
-import { jsonRoundTrip, type BaseSessionStateDto, type ConversationTreeDto, type MessageDto, type ModelDto, type SessionStatsDto, type SlashCommandDto } from "./dto.js";
+import { parseAttachmentMarkup } from "../../shared/attachments.js";
+import type { PiWebSession } from "../../types.js";
+import { jsonRoundTrip, type BaseSessionStateDto, type ConversationTreeDto, type MessageDto, type ModelDto, type SessionStatsDto, type SlashCommandDto } from "../dto.js";
 
 export type ContentDecorator = (content: unknown) => unknown;
 

--- a/server/session/pi/retry.ts
+++ b/server/session/pi/retry.ts
@@ -1,0 +1,73 @@
+import type { PiWebSession } from "../../types.js";
+import {
+  isAssistantAbortedMessage,
+  isAssistantFailureMessage,
+  isIncompleteToolResultMessage,
+} from "./projection.js";
+
+type RetryTarget =
+  | { kind: "failure"; messages: any[] }
+  | { kind: "aborted"; messages: any[] }
+  | { kind: "toolResult"; messages: any[] };
+
+function targetFor(value: PiWebSession): RetryTarget | undefined {
+  const messages = Array.isArray(value.agent?.state?.messages) ? value.agent.state.messages as any[] : [];
+  const message = messages.at(-1);
+  if (isAssistantFailureMessage(message)) return { kind: "failure", messages };
+  if (isAssistantAbortedMessage(message)) return { kind: "aborted", messages };
+  if (isIncompleteToolResultMessage(message)) return { kind: "toolResult", messages };
+  return undefined;
+}
+
+function branchBeforeTrailingMessages(value: PiWebSession, predicate: (message: any) => boolean) {
+  const manager = value.sessionManager;
+  if (!manager.getBranch) return false;
+  let branch: any[];
+  try { branch = manager.getBranch(); } catch { return false; }
+  if (!Array.isArray(branch)) return false;
+  let last = -1;
+  for (let index = branch.length - 1; index >= 0; index--) if (branch[index]?.type === "message") { last = index; break; }
+  if (last < 0 || !predicate(branch[last]?.message)) return false;
+  let first = last;
+  while (first > 0 && branch[first - 1]?.type === "message" && predicate(branch[first - 1].message)) first--;
+  const parentId = typeof branch[first]?.parentId === "string" ? branch[first].parentId : null;
+  if (parentId && manager.branch) manager.branch(parentId);
+  else if (!parentId && manager.resetLeaf) manager.resetLeaf();
+  else return false;
+  return true;
+}
+
+function syncMessages(value: PiWebSession) {
+  if (!value.sessionManager.buildSessionContext) return false;
+  value.agent.state.messages = value.sessionManager.buildSessionContext().messages;
+  return true;
+}
+
+/** Pi-only retry semantics, including compatibility with SDK versions predating retryFromFailure. */
+export function canRetryPiSession(value: PiWebSession): boolean {
+  return Boolean(targetFor(value));
+}
+
+export async function retryPiSession(value: PiWebSession): Promise<{ usedCompatibilityFallback: boolean }> {
+  if (value.retryFromFailure) {
+    await value.retryFromFailure();
+    return { usedCompatibilityFallback: false };
+  }
+  const target = targetFor(value);
+  if (!target) throw new Error("There is no failed or incomplete response to retry.");
+  const internal = value as any;
+  if (!internal.agent || typeof internal.agent.continue !== "function") throw new Error("Continuing is not available in this session.");
+  if (target.kind === "failure") {
+    if (!branchBeforeTrailingMessages(value, isAssistantFailureMessage) || !syncMessages(value)) while (target.messages.length && isAssistantFailureMessage(target.messages.at(-1))) target.messages.pop();
+  } else if (target.kind === "aborted") {
+    if (!branchBeforeTrailingMessages(value, isAssistantAbortedMessage) || !syncMessages(value)) if (isAssistantAbortedMessage(target.messages.at(-1))) target.messages.pop();
+  }
+  try {
+    await internal.agent.continue();
+    while (typeof internal._handlePostAgentRun === "function" && await internal._handlePostAgentRun()) await internal.agent.continue();
+  } finally {
+    internal._systemPromptOverride = undefined;
+    internal._flushPendingBashMessages?.();
+  }
+  return { usedCompatibilityFallback: true };
+}

--- a/server/session/service.ts
+++ b/server/session/service.ts
@@ -42,15 +42,14 @@ import {
   conversationTreeForSession,
   getSessionSlashCommands,
   isAssistantAbortedMessage,
-  isAssistantFailureMessage,
-  isIncompleteToolResultMessage,
   projectCommittedMessage,
   projectMessages,
   projectSessionState,
   sessionDisplayName,
   sessionStats,
   simplifyModel,
-} from "./projection.js";
+} from "./pi/projection.js";
+import { canRetryPiSession, retryPiSession } from "./pi/retry.js";
 
 export class SessionServiceError extends Error {
   constructor(message: string, readonly status = 400) { super(message); }
@@ -115,11 +114,6 @@ type ViewerLease = {
   sockets: Set<symbol>;
   releaseTimer?: ReturnType<typeof setTimeout>;
 };
-
-type RetrySessionTarget =
-  | { kind: "failure"; messages: any[]; index: number; message: any }
-  | { kind: "aborted"; messages: any[]; index: number; message: any }
-  | { kind: "toolResult"; messages: any[]; index: number; message: any };
 
 type PendingPromptCorrelation = {
   clientMessageId: string;
@@ -1323,73 +1317,18 @@ export class LocalSessionService implements SessionService {
     });
   }
 
-  private trailingRetryTarget(value: PiWebSession): RetrySessionTarget | undefined {
-    const messages = Array.isArray(value.agent?.state?.messages) ? value.agent.state.messages as any[] : [];
-    const index = messages.length - 1;
-    const message = messages[index];
-    if (isAssistantFailureMessage(message)) return { kind: "failure", messages, index, message };
-    if (isAssistantAbortedMessage(message)) return { kind: "aborted", messages, index, message };
-    if (isIncompleteToolResultMessage(message)) return { kind: "toolResult", messages, index, message };
-    return undefined;
-  }
-
-  private branchBeforeTrailingMessages(value: PiWebSession, shouldBranchBefore: (message: any) => boolean) {
-    const manager = value.sessionManager;
-    if (!manager.getBranch) return false;
-    let branch: any[];
-    try { branch = manager.getBranch(); } catch { return false; }
-    if (!Array.isArray(branch)) return false;
-    let last = -1;
-    for (let index = branch.length - 1; index >= 0; index--) if (branch[index]?.type === "message") { last = index; break; }
-    if (last < 0 || !shouldBranchBefore(branch[last]?.message)) return false;
-    let first = last;
-    while (first > 0 && branch[first - 1]?.type === "message" && shouldBranchBefore(branch[first - 1].message)) first--;
-    const parentId = typeof branch[first]?.parentId === "string" ? branch[first].parentId : null;
-    if (parentId && manager.branch) manager.branch(parentId);
-    else if (!parentId && manager.resetLeaf) manager.resetLeaf();
-    else return false;
-    return true;
-  }
-
-  private syncAgentMessages(value: PiWebSession) {
-    if (!value.sessionManager.buildSessionContext) return false;
-    value.agent.state.messages = value.sessionManager.buildSessionContext().messages;
-    return true;
-  }
-
-  private assertCanRetry(value: PiWebSession) {
-    if (this.hasActiveWorkForPath(value.sessionFile)) throw new Error("Wait for the current response to finish before retrying.");
-    if (value.isStreaming) throw new Error("Wait for the current response to finish before retrying.");
-    if (value.isCompacting) throw new Error("Wait for compaction to finish before retrying.");
-    if (!this.trailingRetryTarget(value)) throw new Error("There is no failed or incomplete response to retry.");
-  }
-
-  private async retryFromFailure(value: PiWebSession) {
-    if (value.retryFromFailure) return value.retryFromFailure();
-    const target = this.trailingRetryTarget(value);
-    if (!target) throw new Error("There is no failed or incomplete response to retry.");
-    const internal = value as any;
-    if (!internal.agent || typeof internal.agent.continue !== "function") throw new Error("Continuing is not available in this session.");
-    if (target.kind === "failure") {
-      if (!this.branchBeforeTrailingMessages(value, isAssistantFailureMessage) || !this.syncAgentMessages(value)) while (target.messages.length && isAssistantFailureMessage(target.messages.at(-1))) target.messages.pop();
-    } else if (target.kind === "aborted") {
-      if (!this.branchBeforeTrailingMessages(value, isAssistantAbortedMessage) || !this.syncAgentMessages(value)) if (isAssistantAbortedMessage(target.messages.at(-1))) target.messages.pop();
-    }
-    try {
-      await internal.agent.continue();
-      while (typeof internal._handlePostAgentRun === "function" && await internal._handlePostAgentRun()) await internal.agent.continue();
-    } finally {
-      internal._systemPromptOverride = undefined;
-      internal._flushPendingBashMessages?.();
-    }
-  }
-
   private async startSessionRetry(value: PiWebSession) {
-    try { this.assertCanRetry(value); } catch (error) { throw new SessionServiceError(errorMessage(error), 409); }
+    try {
+      if (this.hasActiveWorkForPath(value.sessionFile) || value.isStreaming) throw new Error("Wait for the current response to finish before retrying.");
+      if (value.isCompacting) throw new Error("Wait for compaction to finish before retrying.");
+      if (!canRetryPiSession(value)) throw new Error("There is no failed or incomplete response to retry.");
+    } catch (error) { throw new SessionServiceError(errorMessage(error), 409); }
     this.emitRuntime(value, "ensure");
     const retrySessionFile = value.sessionFile;
-    const usesCompatibilityFallback = !value.retryFromFailure;
-    void this.withWorkLease(value, "retry", "retry", () => this.retryFromFailure(value)).catch((error) => {
+    let usesCompatibilityFallback = false;
+    void this.withWorkLease(value, "retry", "retry", async () => {
+      usesCompatibilityFallback = (await retryPiSession(value)).usedCompatibilityFallback;
+    }).catch((error) => {
       this.emitRuntime(value, "clear", retrySessionFile);
       this.emitError(value, error);
     }).finally(() => {

--- a/server/session/service.ts
+++ b/server/session/service.ts
@@ -298,6 +298,35 @@ export class LocalSessionService implements SessionService {
   }
 
   sessionForPath(path: string) { return this.liveSessions.get(path)?.session; }
+  activityView(value: PiWebSession) {
+    return {
+      sessionId: value.sessionId,
+      sessionFile: value.sessionFile,
+      isStreaming: Boolean(value.isStreaming),
+      isRetrying: Boolean(value.isRetrying),
+      isCompacting: Boolean(value.isCompacting),
+      pendingMessageCount: Number(value.pendingMessageCount || 0),
+      model: simplifyModel(value.model),
+      ...(typeof (value as any).runtimeStartedAt === "string" ? { runtimeStartedAt: (value as any).runtimeStartedAt } : {}),
+      ...(typeof (value as any).runtimeLastActivityAt === "string" ? { runtimeLastActivityAt: (value as any).runtimeLastActivityAt } : {}),
+    };
+  }
+  activityViewForPath(path: string) {
+    const value = this.sessionForPath(path);
+    return value ? this.activityView(value) : undefined;
+  }
+  activityViewForId(id: string) {
+    const value = this.sessionForId(id);
+    return value ? this.activityView(value) : undefined;
+  }
+  projectStateForId(id: string) {
+    const value = this.sessionForId(id);
+    return value ? this.projectState(value) : undefined;
+  }
+  webUiEntriesForId(id: string) {
+    const value = this.sessionForId(id);
+    return value ? this.webUiEntries(value) : undefined;
+  }
   hasActiveWorkForPath(path: string) { return (this.liveSessions.get(path)?.workLeases.size || 0) > 0; }
   hasActiveRetryForPath(path: string) { return Array.from(this.liveSessions.get(path)?.workLeases.values() || []).some((lease) => lease.kind === "retry"); }
   sessionForId(id: string) { return this.liveById.get(id); }

--- a/tests/session-projection.test.ts
+++ b/tests/session-projection.test.ts
@@ -12,7 +12,7 @@ import {
   simplifyMessage,
   simplifyModel,
   textFromContent,
-} from "../server/session/projection.js";
+} from "../server/session/pi/projection.js";
 
 function fixtureSession(): PiWebSession {
   const branch = [

--- a/tests/session-service.test.ts
+++ b/tests/session-service.test.ts
@@ -293,12 +293,12 @@ describe("LocalSessionService contract", () => {
 
   it("executes the synchronous service-to-host event pipeline with exact wire payloads", async () => {
     const { service, fixture, initial } = await fixtureService();
-    const activity = new SessionActivity((path) => service.sessionForPath(path));
+    const activity = new SessionActivity((path) => service.activityViewForPath(path));
     const wire: any[] = [];
     service.subscribe(createHostSessionEventHandler({
-      sessionForId: (id) => service.sessionForId(id),
-      projectState: (value) => service.projectState(value),
-      webUiEntries: (value) => service.webUiEntries(value),
+      sessionViewForId: (id) => service.activityViewForId(id),
+      projectStateForId: (id) => service.projectStateForId(id),
+      webUiEntriesForId: (id) => service.webUiEntriesForId(id),
       sessionActivity: activity,
       broadcast: (value) => wire.push(value),
       markSessionUnreadCompleted: () => undefined,
@@ -381,12 +381,12 @@ describe("LocalSessionService contract", () => {
 
   it("carries unknown harness events through the service and host wire unchanged", async () => {
     const { service, initial } = await fixtureService();
-    const activity = new SessionActivity((path) => service.sessionForPath(path));
+    const activity = new SessionActivity((path) => service.activityViewForPath(path));
     const wire: any[] = [];
     const handler = createHostSessionEventHandler({
-      sessionForId: (id) => service.sessionForId(id),
-      projectState: (value) => service.projectState(value),
-      webUiEntries: (value) => service.webUiEntries(value),
+      sessionViewForId: (id) => service.activityViewForId(id),
+      projectStateForId: (id) => service.projectStateForId(id),
+      webUiEntriesForId: (id) => service.webUiEntriesForId(id),
       sessionActivity: activity,
       broadcast: (value) => wire.push(value),
       markSessionUnreadCompleted: () => undefined,
@@ -404,11 +404,11 @@ describe("LocalSessionService contract", () => {
 
   it("replays the recorded pi 0.84 event fixture through the service/host wire boundary", async () => {
     const { service, initial } = await fixtureService();
-    const activity = new SessionActivity((path) => service.sessionForPath(path));
+    const activity = new SessionActivity((path) => service.activityViewForPath(path));
     const wire: any[] = [];
     const handler = createHostSessionEventHandler({
-      sessionForId: (id) => service.sessionForId(id), projectState: (value) => service.projectState(value),
-      webUiEntries: (value) => service.webUiEntries(value), sessionActivity: activity,
+      sessionViewForId: (id) => service.activityViewForId(id), projectStateForId: (id) => service.projectStateForId(id),
+      webUiEntriesForId: (id) => service.webUiEntriesForId(id), sessionActivity: activity,
       broadcast: (value) => wire.push(value), markSessionUnreadCompleted: () => undefined,
     });
     const mapped = pi084Events.map(mapPiEvent).filter((item) => item.kind === "event");
@@ -424,18 +424,18 @@ describe("LocalSessionService contract", () => {
 
   it("marks unread and sends exactly one notification from the same final completion transition", async () => {
     const { service, initial } = await fixtureService();
-    const activity = new SessionActivity((path) => service.sessionForPath(path));
+    const activity = new SessionActivity((path) => service.activityViewForPath(path));
     const transitions: string[] = [];
     const handler = createHostSessionEventHandler({
-      sessionForId: (id) => service.sessionForId(id),
-      projectState: (value) => service.projectState(value),
-      webUiEntries: (value) => service.webUiEntries(value),
+      sessionViewForId: (id) => service.activityViewForId(id),
+      projectStateForId: (id) => service.projectStateForId(id),
+      webUiEntriesForId: (id) => service.webUiEntriesForId(id),
       sessionActivity: activity,
       broadcast: () => undefined,
       markSessionUnreadCompleted: () => transitions.push("unread"),
       notifySessionCompleted: () => transitions.push("notification"),
     });
-    activity.ensureStarted(initial);
+    activity.ensureStarted(service.activityView(initial));
     const completed: SessionServiceEvent = {
       type: "runtime",
       action: "completed",
@@ -452,14 +452,14 @@ describe("LocalSessionService contract", () => {
 
   it("clears aborted work without marking unread or sending completion push", async () => {
     const { service, initial } = await fixtureService();
-    const activity = new SessionActivity((path) => service.sessionForPath(path));
+    const activity = new SessionActivity((path) => service.activityViewForPath(path));
     const transitions: string[] = [];
     const handler = createHostSessionEventHandler({
-      sessionForId: (id) => service.sessionForId(id), projectState: (value) => service.projectState(value),
-      webUiEntries: (value) => service.webUiEntries(value), sessionActivity: activity, broadcast: () => undefined,
+      sessionViewForId: (id) => service.activityViewForId(id), projectStateForId: (id) => service.projectStateForId(id),
+      webUiEntriesForId: (id) => service.webUiEntriesForId(id), sessionActivity: activity, broadcast: () => undefined,
       markSessionUnreadCompleted: () => transitions.push("unread"), notifySessionCompleted: () => transitions.push("notification"),
     });
-    activity.ensureStarted(initial);
+    activity.ensureStarted(service.activityView(initial));
     handler({ type: "runtime", action: "completed", sessionId: initial.sessionId, sessionFile: initial.sessionFile, aborted: true });
     expect(transitions).toEqual([]);
     expect(activity.hasStarted(initial.sessionFile)).toBe(false);
@@ -471,10 +471,32 @@ describe("LocalSessionService contract", () => {
     await expect(resolveWebSocketHelloSession("corrupt", initial, async () => { throw new Error("corrupt session"); })).rejects.toThrow("corrupt session");
   });
 
+  it("keeps host activity and event translation independent of pi session types", async () => {
+    const [activitySource, hostEventsSource] = await Promise.all([
+      readFile(new URL("../server/session/activity.ts", import.meta.url), "utf8"),
+      readFile(new URL("../server/session/hostEvents.ts", import.meta.url), "utf8"),
+    ]);
+    for (const source of [activitySource, hostEventsSource]) {
+      expect(source).not.toContain("PiWebSession");
+      expect(source).not.toMatch(/from ["']\.\/pi\//);
+      expect(source).not.toMatch(/from ["']\.\.\/types/);
+    }
+  });
+
+  it("tracks runtime timestamps without mutating the neutral session view", () => {
+    const view = { sessionFile: "/tmp/neutral.jsonl", sessionId: "neutral", isStreaming: true, isRetrying: false, isCompacting: false, pendingMessageCount: 0 };
+    const activity = new SessionActivity(() => view);
+    activity.enrichEvent(view, { type: "agent_start", startedAt: "2026-03-01T00:00:00.000Z" });
+    expect(view).not.toHaveProperty("runtimeStartedAt");
+    expect(activity.startedAtForPath(view.sessionFile, true)).toBe("2026-03-01T00:00:00.000Z");
+    activity.clearStarted(view);
+    expect(activity.hasStarted(view.sessionFile)).toBe(false);
+  });
+
   it("decorates ID-less tool calls by their matching content position", () => {
     const activity = new SessionActivity(() => undefined);
     const sessionFile = "/tmp/id-less.jsonl";
-    activity.enrichEvent({ sessionFile, sessionId: "id-less" } as PiWebSession, { type: "tool_execution_start", toolName: "read", startedAt: "2026-03-01T00:00:00.000Z" });
+    activity.enrichEvent({ sessionFile, sessionId: "id-less", isStreaming: false, isRetrying: false, isCompacting: false, pendingMessageCount: 0 }, { type: "tool_execution_start", toolName: "read", startedAt: "2026-03-01T00:00:00.000Z" });
     const messages: MessageDto[] = [{
       role: "assistant",
       isError: false,
@@ -491,7 +513,7 @@ describe("LocalSessionService standalone lifecycle", () => {
   it("keeps agent_end running and uses agent_settled as the idle boundary", async () => {
     const { service, fixture, initial } = await fixtureService();
     const activity = new SessionActivity(
-      (path) => service.sessionForPath(path),
+      (path) => service.activityViewForPath(path),
       (path) => service.hasActiveWorkForPath(path),
       (path) => service.hasActiveRetryForPath(path),
     );
@@ -511,7 +533,7 @@ describe("LocalSessionService standalone lifecycle", () => {
     const retryGate = new Promise<void>((resolve) => { releaseRetry = resolve; });
     initial.retryFromFailure = vi.fn(() => retryGate);
     const activity = new SessionActivity(
-      (path) => service.sessionForPath(path),
+      (path) => service.activityViewForPath(path),
       (path) => service.hasActiveWorkForPath(path),
       (path) => service.hasActiveRetryForPath(path),
     );
@@ -657,12 +679,12 @@ describe("LocalSessionService standalone lifecycle", () => {
 
   it("captures operation paths and clears both registration and current paths on shutdown", async () => {
     const { service, initial } = await fixtureService();
-    const activity = new SessionActivity((path) => service.sessionForPath(path));
+    const activity = new SessionActivity((path) => service.activityViewForPath(path));
     const wire: unknown[] = [];
     service.subscribe(createHostSessionEventHandler({
-      sessionForId: (id) => service.sessionForId(id),
-      projectState: (value) => service.projectState(value),
-      webUiEntries: (value) => service.webUiEntries(value),
+      sessionViewForId: (id) => service.activityViewForId(id),
+      projectStateForId: (id) => service.projectStateForId(id),
+      webUiEntriesForId: (id) => service.webUiEntriesForId(id),
       sessionActivity: activity,
       broadcast: (value) => wire.push(value),
       markSessionUnreadCompleted: () => undefined,


### PR DESCRIPTION
## Summary

First coherent H1 preparation slice for #92. Moves Pi-shaped projection and retry/private-SDK behavior under `server/session/pi/` without introducing an unused or parallel adapter path.

## Changes

- moves `server/session/projection.ts` to `server/session/pi/projection.ts`;
- extracts Pi retry semantics into `server/session/pi/retry.ts`;
- contains transcript branching, agent-message synchronization, `agent.continue()`, `_handlePostAgentRun`, `_systemPromptOverride`, and `_flushPendingBashMessages` behind Pi-specific helpers;
- simplifies `LocalSessionService` to call the Pi retry boundary;
- updates server/mock/activity/tests to the canonical projection location.

## Why this slice

The complete opaque-handle adapter conversion touches live-session ownership, host activity, extension binding, creation/listing/persistence, production composition, and the mock harness together. Adding unused adapter interfaces before converting those owners would create a second abstraction path. This PR instead removes two concrete categories of Pi coupling while preserving one canonical implementation.

This is stacked on #119. It does **not** claim to complete H1; creation/events/extensions and the Pi-shaped mock remain follow-up work.

## Validation

- `npm run typecheck`
- focused tests: 42 passed (`session-projection`, `session-service`, `pi-event-map`)
- full `npm test` passed
- `npm run build` passed
