### PR TITLE
fix: never let a stale tab wipe session UI state (#127)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -8,7 +8,7 @@ import { WebSocketServer, type WebSocket } from "ws";
 import { getAgentDir, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { createMockHarness } from "./server/mock.js";
 import { resolveBundledExtensionPaths, resolvePiWebExtensionPaths } from "./server/extensions.js";
-import { createSessionUiStateStore, defaultSessionUiState } from "./server/sessionUiState.js";
+import { createSessionUiStateStore, defaultSessionUiState, SessionUiStateShrinkRejected } from "./server/sessionUiState.js";
 import { ExtensionRevisionConflictError, ExtensionSettingsBoundsError } from "./server/settings.js";
 import { defaultSettingsValues, validateSettingsValues } from "./server/extensionSettings.js";
 import { findArtifactFile, isValidArtifactPath } from "./server/shared/artifacts.js";
@@ -898,9 +898,16 @@ const server = createServer(withAccessLog(async (req, res, url) => {
       }
 
       if (method === "PATCH" && url.pathname === "/api/session-ui-state") {
-        const sessionUiState = await sessionUiStateStore.patch(await readBody(req));
-        broadcast({ type: "session_ui_state_changed", sessionUiState });
-        return sendJson(res, 200, { ok: true, sessionUiState });
+        try {
+          const sessionUiState = await sessionUiStateStore.patch(await readBody(req));
+          broadcast({ type: "session_ui_state_changed", sessionUiState });
+          return sendJson(res, 200, { ok: true, sessionUiState });
+        } catch (error) {
+          if (error instanceof SessionUiStateShrinkRejected) {
+            return sendJson(res, 409, { ok: false, error: "refusing to shrink session UI state", details: error.details });
+          }
+          throw error;
+        }
       }
 
       if (method === "POST" && (url.pathname === "/api/session-ui-state/read" || url.pathname === "/api/session-ui-state/unread")) {

--- a/server/sessionUiState.ts
+++ b/server/sessionUiState.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { access, copyFile, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 export type SessionMarkerColorId = "blue" | "purple" | "yellow" | "red" | "green" | "orange" | "cyan" | "pink";
@@ -61,7 +61,25 @@ export type SessionUiStatePatch = Partial<{
   selectedMarkerColor: unknown;
   allowedMarkerColors: unknown;
   bucketLabels: unknown;
+  force: unknown;
 }>;
+
+type GuardedSessionUiStateCollection = "lanes" | "sessionMarkers" | "sessionUnreadStates" | "sessionOrigins";
+export type SessionUiStateShrinkDetails = { collection: GuardedSessionUiStateCollection; current: number; next: number };
+
+export class SessionUiStateShrinkRejected extends Error {
+  readonly details: SessionUiStateShrinkDetails;
+
+  constructor(details: SessionUiStateShrinkDetails) {
+    super(`Refusing to shrink ${details.collection} from ${details.current} to ${details.next}`);
+    this.name = "SessionUiStateShrinkRejected";
+    this.details = details;
+  }
+}
+
+export const SESSION_UI_STATE_SHRINK_MINIMUM_SIZE = 10;
+export const SESSION_UI_STATE_MAX_SHRINK_FRACTION = 0.5;
+const guardedSessionUiStateCollections: GuardedSessionUiStateCollection[] = ["lanes", "sessionMarkers", "sessionUnreadStates", "sessionOrigins"];
 
 const markerColors = new Set<SessionMarkerColorId>(["blue", "purple", "yellow", "red", "green", "orange", "cyan", "pink"]);
 const legacyBucketToColor: Record<string, SessionMarkerColorId> = {
@@ -328,6 +346,29 @@ export function createSessionUiStateStore(file: string) {
     return cloneState(cached);
   }
 
+  async function backUpCurrentStateFile() {
+    try {
+      await access(file);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+
+    await rm(`${file}.bak-5.json`, { force: true });
+    for (let index = 5; index >= 2; index -= 1) {
+      try {
+        await rename(`${file}.bak-${index - 1}.json`, `${file}.bak-${index}.json`);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+    }
+    try {
+      await copyFile(file, `${file}.bak-1.json`);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+
   async function writeState(state: SessionUiState) {
     if (futureVersion !== undefined) throw new Error(`Session UI state version ${futureVersion} is newer than this build; refusing to overwrite ${file}`);
     const normalized = normalizeSessionUiState(state);
@@ -335,6 +376,7 @@ export function createSessionUiStateStore(file: string) {
     await mkdir(dirname(file), { recursive: true });
     const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
     await writeFile(tmp, `${JSON.stringify(cached, null, 2)}\n`, "utf-8");
+    await backUpCurrentStateFile();
     await rename(tmp, file);
     return cloneState(cached);
   }
@@ -344,7 +386,25 @@ export function createSessionUiStateStore(file: string) {
   }
 
   async function patch(value: SessionUiStatePatch | unknown) {
-    return serializeWrite(async () => writeState(applySessionUiStatePatch(await read(), value)));
+    return serializeWrite(async () => {
+      const current = await read();
+      const force = isRecord(value) && value.force === true;
+      const patchWithoutForce = isRecord(value)
+        ? Object.fromEntries(Object.entries(value).filter(([key]) => key !== "force"))
+        : value;
+      const next = applySessionUiStatePatch(current, patchWithoutForce);
+      if (!force) {
+        for (const collection of guardedSessionUiStateCollections) {
+          const currentSize = current[collection].length;
+          const nextSize = next[collection].length;
+          if (currentSize >= SESSION_UI_STATE_SHRINK_MINIMUM_SIZE
+            && (currentSize - nextSize) / currentSize > SESSION_UI_STATE_MAX_SHRINK_FRACTION) {
+            throw new SessionUiStateShrinkRejected({ collection, current: currentSize, next: nextSize });
+          }
+        }
+      }
+      return writeState(next);
+    });
   }
 
   async function markUnread(sessionId: string, unreadAt = new Date().toISOString()) {

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -390,6 +390,32 @@ export function normalizeSessionUiState(value: unknown): SessionUiState {
   };
 }
 
+export type SessionUiStateResponse = { ok: boolean; status?: number; sessionUiState?: unknown };
+
+export function sessionUiStateFromResponse(response: SessionUiStateResponse): SessionUiState | undefined {
+  if (!response.ok || !response.sessionUiState || typeof response.sessionUiState !== "object" || Array.isArray(response.sessionUiState)) return undefined;
+  const revision = (response.sessionUiState as Record<string, unknown>).revision;
+  if (typeof revision !== "number" || !Number.isSafeInteger(revision) || revision < 0) return undefined;
+  return normalizeSessionUiState(response.sessionUiState);
+}
+
+export function hasAnySessionUiState(value: SessionUiState) {
+  return value.lanes.length > 0
+    || value.sessionNotes.length > 0
+    || value.pinnedFolders.length > 0
+    || value.sessionMarkers.length > 0
+    || value.sessionUnreadStates.length > 0
+    || value.sessionOrigins.length > 0
+    || value.allowedMarkerColors.length > 0
+    || Object.keys(value.bucketLabels).length > 0
+    || value.selectedMarkerColor !== defaultSessionUiState.selectedMarkerColor;
+}
+
+export function shouldMigrateLocalUiState(response: SessionUiStateResponse, localState: SessionUiState) {
+  const serverState = sessionUiStateFromResponse(response);
+  return serverState?.revision === 0 && hasAnySessionUiState(localState);
+}
+
 export function readLegacyPinnedSessions(): PinnedSession[] {
   try {
     return normalizePinnedSessions(JSON.parse(localStorage.getItem(pinnedSessionsKey) || "[]"));

--- a/src/sessions/sessionDrawer.ts
+++ b/src/sessions/sessionDrawer.ts
@@ -6,7 +6,7 @@ import type { RightPanelHandle, RightPanelManager } from "../layout/rightPanel.j
 import { panelOverlayModeQuery } from "../layout/responsive.js";
 import type { AppState, SessionInfo, SessionLaneEntry, SessionLaneId, SessionMarkerColorId, SessionUiState } from "../app/types.js";
 import { sessionRuntime, type SessionStateController } from "../app/sessionState.js";
-import { defaultSessionUiState, normalizeSessionUiState, persistCollapsedSessionFolders, persistExpandedWorkerBranches, sessionFolderPreviewLimit, sessionMarkerColors, writeActiveSessionIdToUrl } from "../app/types.js";
+import { normalizeSessionUiState, persistCollapsedSessionFolders, persistExpandedWorkerBranches, sessionFolderPreviewLimit, sessionMarkerColors, sessionUiStateFromResponse, shouldMigrateLocalUiState, writeActiveSessionIdToUrl } from "../app/types.js";
 import { runningChildIdsOf, sessionIndicatorKind, waitingInfoFrom, type WaitingInfo } from "./lineage.js";
 import { buildSpawnWorkerForest, deriveWorkerBranchView, type WorkerBranchView } from "./workerBranches.js";
 import { buildSessionInspector } from "./sessionInspector.js";
@@ -648,9 +648,9 @@ export function createSessions(options: {
   let sessionUiStateInitialized = false;
   let restoredPersistedLaneFocus = false;
   let sessionUiWriteQueue = Promise.resolve();
-  function applySessionUiStateValue(value: unknown) {
+  function applySessionUiStateValue(value: unknown, force = false) {
     const next = normalizeSessionUiState(value);
-    if (sessionUiStateInitialized && next.revision <= latestSessionUiRevision) return;
+    if (!force && sessionUiStateInitialized && next.revision <= latestSessionUiRevision) return;
     sessionUiStateInitialized = true;
     latestSessionUiRevision = next.revision;
     state.lanes = next.lanes;
@@ -678,26 +678,24 @@ export function createSessions(options: {
     }
   }
 
-  function hasAnySessionUiState(value: SessionUiState) {
-    return value.lanes.length > 0
-      || value.sessionNotes.length > 0
-      || value.pinnedFolders.length > 0
-      || value.sessionMarkers.length > 0
-      || value.sessionUnreadStates.length > 0
-      // Lineage counts as state: without it, a server holding ONLY origins looks
-      // "empty" and a legacy-localStorage push would wipe every recorded origin.
-      || (value.sessionOrigins?.length ?? 0) > 0
-      || value.allowedMarkerColors.length > 0
-      || Object.keys(value.bucketLabels).length > 0
-      || value.selectedMarkerColor !== defaultSessionUiState.selectedMarkerColor;
-  }
-
   function applySessionUiState(value: unknown) {
     // Realtime snapshots emitted before our PATCH response can contain the old
     // lane projection. Let the mutation response remain authoritative while a
     // local write is in flight so a newly pinned tab cannot immediately revert.
     if (sessionUiWritePending > 0) return;
     applySessionUiStateValue(value);
+  }
+
+  async function fetchSessionUiStateSnapshot() {
+    const res = await fetch("/api/session-ui-state", { headers: api.headers() });
+    const data = await res.json().catch(() => ({}));
+    const response = {
+      ok: res.ok && data.ok !== false,
+      status: res.status,
+      sessionUiState: data.sessionUiState,
+    };
+    const sessionUiState = sessionUiStateFromResponse(response);
+    return sessionUiState ? { response, sessionUiState } : undefined;
   }
 
   async function patchSessionUiState(patch: Partial<SessionUiState>) {
@@ -710,7 +708,13 @@ export function createSessions(options: {
         body: JSON.stringify(patch),
       });
       const data = await res.json().catch(() => ({}));
-      if (!res.ok || data.ok === false) throw new Error(data.error || await res.text());
+      if (res.status === 409) {
+        console.warn("Session UI state patch was refused; reloading server state.", data.details);
+        const snapshot = await fetchSessionUiStateSnapshot();
+        if (snapshot) applySessionUiStateValue(snapshot.sessionUiState, true);
+        return;
+      }
+      if (!res.ok || data.ok === false) throw new Error(data.error || `Session UI state update failed (${res.status})`);
       // Keep newer optimistic mutations rendered until their queued write is
       // confirmed; intermediate full-state responses would otherwise revert UI.
       if (writeSequence === sessionUiWriteSequence) applySessionUiStateValue(data.sessionUiState);
@@ -735,26 +739,26 @@ export function createSessions(options: {
   }
 
   async function refreshSessionUiState() {
-    const res = await fetch("/api/session-ui-state", { headers: api.headers() });
-    if (res.status === 401) return;
-    const data = await res.json().catch(() => ({}));
-    if (!res.ok || data.ok === false) throw new Error(data.error || await res.text());
-    const serverState = normalizeSessionUiState(data.sessionUiState);
+    // Capture the boot-time legacy projection before another server snapshot can
+    // replace it while this request is in flight. It is migration input only.
     const localState = normalizeSessionUiState({
       lanes: state.lanes,
       sessionNotes: state.sessionNotes,
       pinnedFolders: state.pinnedFolders,
       sessionMarkers: state.sessionMarkers,
       sessionUnreadStates: state.sessionUnreadStates,
+      sessionOrigins: state.sessionOrigins,
       selectedMarkerColor: state.selectedMarkerColor,
       allowedMarkerColors: Array.from(allowedMarkerColors),
       bucketLabels: state.bucketLabels,
     });
-    if (!hasAnySessionUiState(serverState) && hasAnySessionUiState(localState)) {
+    const snapshot = await fetchSessionUiStateSnapshot();
+    if (!snapshot) return;
+    if (latestSessionUiRevision === 0 && shouldMigrateLocalUiState(snapshot.response, localState)) {
       await patchSessionUiState(localState);
       return;
     }
-    applySessionUiState(serverState);
+    applySessionUiState(snapshot.sessionUiState);
   }
 
   function unreadStateForSession(sessionId: string) {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -426,6 +426,43 @@ describe("pi-web mock API", () => {
     ]);
   });
 
+  it("returns 409 when a session UI state patch would remove most entries", async () => {
+    const original = (await (await fetch(`${baseUrl}/api/session-ui-state`)).json()).sessionUiState;
+    const lanes = Array.from({ length: 20 }, (_, index) => ({
+      sessionId: `shrink-guard-${index}`,
+      lane: "pinned",
+      since: "2026-01-01T00:00:00.000Z",
+    }));
+    try {
+      const seeded = await fetch(`${baseUrl}/api/session-ui-state`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ lanes, force: true }),
+      });
+      expect(seeded.status).toBe(200);
+
+      const rejected = await fetch(`${baseUrl}/api/session-ui-state`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ lanes: lanes.slice(0, 3) }),
+      });
+      expect(rejected.status).toBe(409);
+      expect(await rejected.json()).toEqual({
+        ok: false,
+        error: "refusing to shrink session UI state",
+        details: { collection: "lanes", current: 20, next: 3 },
+      });
+      const current = await (await fetch(`${baseUrl}/api/session-ui-state`)).json();
+      expect(current.sessionUiState.lanes).toHaveLength(20);
+    } finally {
+      await fetch(`${baseUrl}/api/session-ui-state`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ...original, force: true }),
+      });
+    }
+  });
+
   it("applies saved defaults to new sessions", async () => {
     try {
       await fetch(`${baseUrl}/api/settings`, {

--- a/tests/session-ui-state-client.test.ts
+++ b/tests/session-ui-state-client.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSessionUiState, shouldMigrateLocalUiState } from "../src/app/types.js";
+
+const localState = normalizeSessionUiState({
+  lanes: [{ sessionId: "legacy-pin", lane: "pinned", since: "2025-01-01T00:00:00.000Z" }],
+});
+
+describe("session UI state first-run migration", () => {
+  it("migrates legacy local state only when the server explicitly reports revision zero", () => {
+    expect(shouldMigrateLocalUiState({
+      ok: true,
+      status: 200,
+      sessionUiState: { revision: 0 },
+    }, localState)).toBe(true);
+  });
+
+  it("does not migrate over an initialized server even when its collections are empty", () => {
+    expect(shouldMigrateLocalUiState({
+      ok: true,
+      status: 200,
+      sessionUiState: { revision: 7 },
+    }, localState)).toBe(false);
+  });
+
+  it("does not migrate after an unauthorized or empty response", () => {
+    expect(shouldMigrateLocalUiState({ ok: false, status: 401 }, localState)).toBe(false);
+    expect(shouldMigrateLocalUiState({ ok: true, status: 200 }, localState)).toBe(false);
+  });
+});

--- a/tests/session-ui-state.test.ts
+++ b/tests/session-ui-state.test.ts
@@ -2,7 +2,11 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { createSessionUiStateStore, defaultSessionUiState } from "../server/sessionUiState.js";
+import { createSessionUiStateStore, defaultSessionUiState, SessionUiStateShrinkRejected } from "../server/sessionUiState.js";
+
+const since = "2025-01-01T00:00:00.000Z";
+const lanes = (count: number) => Array.from({ length: count }, (_, index) => ({ sessionId: `session-${index}`, lane: "pinned" as const, since }));
+const unreadStates = (count: number) => Array.from({ length: count }, (_, index) => ({ sessionId: `session-${index}`, unreadAt: since, updatedAt: since }));
 
 const dirs: string[] = [];
 afterEach(async () => { await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))); });
@@ -79,10 +83,65 @@ describe("session UI state store", () => {
   it("preserves since for unchanged pins sent through the legacy alias", async () => {
     const file = await tempFile();
     const store = createSessionUiStateStore(file);
-    const since = "2025-01-01T00:00:00.000Z";
     await store.write({ ...defaultSessionUiState, lanes: [{ sessionId: "a", lane: "pinned", since }] });
 
     const next = await store.patch({ pinnedSessions: [{ id: "a", cwd: "/tmp/a" }] });
     expect(next.lanes).toEqual([{ sessionId: "a", lane: "pinned", cwd: "/tmp/a", since }]);
+  });
+
+  it("rejects a patch that shrinks a non-trivial collection by more than half without changing the file", async () => {
+    const file = await tempFile();
+    const store = createSessionUiStateStore(file);
+    await store.write({ ...defaultSessionUiState, lanes: lanes(20) });
+    const before = await readFile(file, "utf8");
+
+    await expect(store.patch({ lanes: lanes(3) })).rejects.toMatchObject({
+      name: SessionUiStateShrinkRejected.name,
+      details: { collection: "lanes", current: 20, next: 3 },
+    });
+    expect(await readFile(file, "utf8")).toBe(before);
+  });
+
+  it("allows the same large shrink when force is true", async () => {
+    const store = createSessionUiStateStore(await tempFile());
+    await store.write({ ...defaultSessionUiState, lanes: lanes(20) });
+
+    const next = await store.patch({ lanes: lanes(3), force: true });
+    expect(next.lanes).toHaveLength(3);
+  });
+
+  it("allows shrinking collections below the non-trivial size threshold", async () => {
+    const store = createSessionUiStateStore(await tempFile());
+    await store.write({ ...defaultSessionUiState, lanes: lanes(4) });
+
+    const next = await store.patch({ lanes: lanes(1) });
+    expect(next.lanes).toHaveLength(1);
+  });
+
+  it("allows POST-style single-entry read and unread changes", async () => {
+    const store = createSessionUiStateStore(await tempFile());
+    await store.patch({ sessionUnreadStates: unreadStates(20) });
+
+    const read = await store.markRead("session-0");
+    expect(read.sessionUnreadStates).toHaveLength(19);
+    const unread = await store.markUnread("new-session", since);
+    expect(unread.sessionUnreadStates).toHaveLength(20);
+    expect(unread.sessionUnreadStates[0]?.sessionId).toBe("new-session");
+  });
+
+  it("keeps five rolling backups of the previous persisted state", async () => {
+    const file = await tempFile();
+    const store = createSessionUiStateStore(file);
+    await store.patch({ pinnedFolders: ["/write-1"] });
+    await store.patch({ pinnedFolders: ["/write-2"] });
+    expect(JSON.parse(await readFile(`${file}.bak-1.json`, "utf8")).pinnedFolders).toEqual(["/write-1"]);
+
+    await store.patch({ pinnedFolders: ["/write-3"] });
+    expect(JSON.parse(await readFile(`${file}.bak-1.json`, "utf8")).pinnedFolders).toEqual(["/write-2"]);
+    expect(JSON.parse(await readFile(`${file}.bak-2.json`, "utf8")).pinnedFolders).toEqual(["/write-1"]);
+
+    for (let index = 4; index <= 7; index += 1) await store.patch({ pinnedFolders: [`/write-${index}`] });
+    await Promise.all(Array.from({ length: 5 }, (_, index) => readFile(`${file}.bak-${index + 1}.json`, "utf8")));
+    await expect(readFile(`${file}.bak-6.json`, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 });


### PR DESCRIPTION
Fixes #127.

## What was happening
A browser tab reconnecting while the server restarts (or any transient empty/401 read of `/api/session-ui-state`) took the first-run migration branch in `refreshSessionUiState()` — *"server has no state, local has some → push local"* — and PATCHed its **boot-time `localStorage` seed** (months-stale pins, empty everything else) over the server's state. `applySessionUiStatePatch` replaces every collection present in the patch, and `writeState` overwrote the only copy. Result: pins, parked/bookmarked lanes, markers, unread flags and origins wiped in one write (observed: 417 KB → 1 KB).

## Fix
**Client**
- Migration local→server happens only when the server *explicitly* reports first run (`revision === 0`) — extracted as the pure `shouldMigrateLocalUiState(response, localState)` so it's unit-testable. Empty/failed/401 reads no longer trigger any write.
- Once the server has answered with `revision > 0`, server state is authoritative. A 409 on PATCH re-fetches and applies server state (with a `console.warn`) instead of retrying.

**Server**
- `patch()` refuses a change that would shrink `lanes` / `sessionMarkers` / `sessionUnreadStates` / `sessionOrigins` by more than 50% when the collection currently holds ≥ 10 entries, unless the patch carries `force: true` (typed `SessionUiStateShrinkRejected` → HTTP **409** with `{ collection, current, next }`). Single-entry read/unread updates are unaffected. Constants: `SESSION_UI_STATE_SHRINK_MINIMUM_SIZE`, `SESSION_UI_STATE_MAX_SHRINK_FRACTION`.
- Before every persist the current file is rotated into `<file>.bak-1…5.json`, so any future loss is one copy away.

## Tests
- store: shrink refused / forced / below-threshold allowed / single-entry changes / backup rotation to 5
- api: PATCH → 409 with details; force path
- client: `shouldMigrateLocalUiState` — revision 0 → migrate; revision > 0 with empty collections → no; failed response → no

`npm run typecheck` · `npm run build` · vitest 63/63 · playwright 365 passed / 10 skipped.

## Follow-up (not in this PR)
Pinned/parked/bookmarked sessions whose cwd isn't in the active set render as "not found" in the drawer even though their files exist — the lane entry already carries `cwd`; the drawer should resolve pinned sessions by id regardless of the active-cwd listing.
